### PR TITLE
Fix retired Anthropic model causing 404 errors

### DIFF
--- a/configs/base.toml
+++ b/configs/base.toml
@@ -14,7 +14,7 @@ format = "%(asctime)s %(name)s [%(levelname)s] %(message)s"
 
 [llm_profiles.anthropic_extraction]
 provider = "anthropic"
-model = "claude-3-5-haiku-20241022"
+model = "claude-haiku-4-5"
 temperature = 0.0
 max_tokens = 512
 
@@ -38,7 +38,7 @@ max_tokens = 8192
 
 [llm_profiles.anthropic_interview_generation]
 provider = "anthropic"
-model = "claude-3-5-haiku-20241022"
+model = "claude-haiku-4-5"
 temperature = 0.7
 max_tokens = 1024
 

--- a/docs/design/configuration.md
+++ b/docs/design/configuration.md
@@ -48,7 +48,7 @@ format = "%(asctime)s %(name)s [%(levelname)s] %(message)s"
 ```toml
 [llm_profiles.anthropic_extraction]
 provider = "anthropic"
-model = "claude-3-5-haiku-20241022"
+model = "claude-haiku-4-5"
 temperature = 0.0
 max_tokens = 512
 ```
@@ -96,7 +96,7 @@ config.evaluation_criteria.remote_required   # ✅ Works
 ```toml
 [llm_profiles.anthropic_extraction]
 provider = "anthropic"
-model = "claude-3-5-haiku-20241022"
+model = "claude-haiku-4-5"
 
 [llm_profiles.another_profile]
 provider = "openai"

--- a/docs/design/llm-factory-pattern.md
+++ b/docs/design/llm-factory-pattern.md
@@ -73,7 +73,7 @@ from src.config.models import LLMProfileConfig
 # Create client via factory
 config = LLMProfileConfig(
     provider="anthropic",
-    model="claude-3-5-haiku-20241022",
+    model="claude-haiku-4-5",
     api_key="your-api-key"
 )
 client = get_llm_client(config)
@@ -206,7 +206,7 @@ _DEFAULT_PROVIDERS: Dict[str, str] = {
 ```python
 # src/config/models.py - Add to VALID_MODELS
 VALID_MODELS: ClassVar[Dict[str, set]] = {
-    "anthropic": {"claude-3-5-haiku-20241022", ...},
+    "anthropic": {"claude-haiku-4-5", ...},
     "google": {"gemini-2.5-flash", ...},
     "openai": {"gpt-4", "gpt-3.5-turbo", ...},  # ← Add models
 }
@@ -332,7 +332,7 @@ job_evaluation_extraction = "anthropic_extraction"
 
 [llm_profiles.anthropic_extraction]
 provider = "anthropic"
-model = "claude-3-5-haiku-20241022"
+model = "claude-haiku-4-5"
 temperature = 0.0
 max_tokens = 512
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -109,7 +109,7 @@ The application uses TOML configuration files in the `configs/` directory:
 ```toml
 [llm_profiles.anthropic_extraction]
 provider = "anthropic"
-model = "claude-3-5-haiku-20241022"
+model = "claude-haiku-4-5"
 temperature = 0.0
 max_tokens = 512
 ```

--- a/src/config/models.py
+++ b/src/config/models.py
@@ -94,10 +94,11 @@ class LLMProfileConfig(BaseModel):
     # Valid models for each provider
     VALID_MODELS: ClassVar[Dict[str, set]] = {
         "anthropic": {
-            "claude-3-5-haiku-20241022",
-            "claude-3-5-haiku-latest",
-            "claude-3-haiku-20240307",
+            "claude-haiku-4-5",
+            "claude-haiku-4-5-20251001",
+            "claude-sonnet-4-6",
             "claude-sonnet-4-20250514",
+            "claude-opus-4-7",
         },
         "google": {
             "gemini-2.5-pro",

--- a/src/llm/common/factory.py
+++ b/src/llm/common/factory.py
@@ -66,7 +66,7 @@ class LLMClientFactory:
             LLMProviderError: If the provider is not supported or client creation fails
 
         Example:
-            config = LLMProfileConfig(provider="anthropic", model="claude-3-5-haiku-20241022")
+            config = LLMProfileConfig(provider="anthropic", model="claude-haiku-4-5")
             client = factory.create_client(config)
         """
         provider = config.provider.lower()
@@ -194,7 +194,7 @@ def get_llm_client(config: LLMProfileConfig) -> BaseLLMClient:
         BaseLLMClient: An instance of the appropriate client implementation
 
     Example:
-        config = LLMProfileConfig(provider="anthropic", model="claude-3-5-haiku-20241022")
+        config = LLMProfileConfig(provider="anthropic", model="claude-haiku-4-5")
         client = get_llm_client(config)
     """
     return _global_factory.create_client(config)

--- a/tests/unit/config/test_system.py
+++ b/tests/unit/config/test_system.py
@@ -574,7 +574,7 @@ ic_title_requirements = ["senior", "staff", "principal"]
 
 [llm_profiles.claude_profile]
 provider = "anthropic"
-model = "claude-3-5-haiku-20241022"
+model = "claude-haiku-4-5"
 temperature = 0.1
 max_tokens = 2048
 
@@ -631,4 +631,4 @@ temperature = 0.0
             assert profile.provider == "anthropic"
 
             agent_profile = settings.get_agent_llm_profile("job_evaluation_extraction")
-            assert agent_profile.model == "claude-3-5-haiku-20241022"
+            assert agent_profile.model == "claude-haiku-4-5"

--- a/tests/unit/integration/test_api_key_validation.py
+++ b/tests/unit/integration/test_api_key_validation.py
@@ -22,7 +22,7 @@ class TestAPIKeyValidation:
         # Create config without API key in environment
         config = LLMProfileConfig(
             provider="anthropic",
-            model="claude-3-5-haiku-20241022",
+            model="claude-haiku-4-5",
             # No api_key provided
         )
 
@@ -44,21 +44,21 @@ class TestAPIKeyValidation:
         """Test that Anthropic client accepts a valid API key format."""
         config_with_key = LLMProfileConfig(
             provider="anthropic",
-            model="claude-3-5-haiku-20241022",
+            model="claude-haiku-4-5",
             api_key="sk-ant-api03-test-key-format",
         )
 
         # This should not raise an error
         client = get_llm_client(config_with_key)
         assert client is not None
-        assert client.get_model_name() == "claude-3-5-haiku-20241022"
+        assert client.get_model_name() == "claude-haiku-4-5"
 
     def test_different_providers_require_different_api_keys(self):
         """Test that different providers validate their specific API key environment variables."""
         # Test Anthropic
         anthropic_config = LLMProfileConfig(
             provider="anthropic",
-            model="claude-3-5-haiku-20241022",
+            model="claude-haiku-4-5",
         )
 
         # Test Google
@@ -100,7 +100,7 @@ class TestAPIKeyValidation:
             # Create config with explicit API key
             config = LLMProfileConfig(
                 provider="anthropic",
-                model="claude-3-5-haiku-20241022",
+                model="claude-haiku-4-5",
                 api_key=config_key,
             )
 

--- a/tests/unit/llm/clients/test_anthropic.py
+++ b/tests/unit/llm/clients/test_anthropic.py
@@ -23,7 +23,7 @@ class TestAnthropicClientInitialization:
         """Test successful client initialization with valid configuration."""
         config = LLMProfileConfig(
             provider="anthropic",
-            model="claude-3-5-haiku-20241022",
+            model="claude-haiku-4-5",
             temperature=0.7,
             max_tokens=1000,
             api_key="test-api-key",
@@ -32,7 +32,7 @@ class TestAnthropicClientInitialization:
         client = AnthropicClient(config)
 
         assert client.config == config
-        assert client.get_model_name() == "claude-3-5-haiku-20241022"
+        assert client.get_model_name() == "claude-haiku-4-5"
         assert client._client is None  # Lazy initialization
 
     def test_invalid_provider_raises_error(self):
@@ -40,7 +40,7 @@ class TestAnthropicClientInitialization:
         # Since LLMProfileConfig validates the provider, we need to test the AnthropicClient's
         # own validation by creating a config with valid provider but then changing it
         config = LLMProfileConfig(
-            provider="anthropic", model="claude-3-5-haiku-20241022", api_key="test-key"
+            provider="anthropic", model="claude-haiku-4-5", api_key="test-key"
         )
 
         # Manually change the provider to test AnthropicClient validation
@@ -55,7 +55,7 @@ class TestAnthropicClientInitialization:
         """Test that missing API key raises LLMProviderError."""
         config = LLMProfileConfig(
             provider="anthropic",
-            model="claude-3-5-haiku-20241022",
+            model="claude-haiku-4-5",
             api_key=None,  # No API key in config
         )
 
@@ -68,7 +68,7 @@ class TestAnthropicClientInitialization:
         """Test that API key can be loaded from environment variable."""
         config = LLMProfileConfig(
             provider="anthropic",
-            model="claude-3-5-haiku-20241022",
+            model="claude-haiku-4-5",
             api_key=None,  # No API key in config
         )
 
@@ -82,7 +82,7 @@ class TestAnthropicClientInitialization:
         """Test that config API key takes precedence over environment variable."""
         config = LLMProfileConfig(
             provider="anthropic",
-            model="claude-3-5-haiku-20241022",
+            model="claude-haiku-4-5",
             api_key="config-api-key",
         )
 
@@ -97,7 +97,7 @@ class TestAnthropicClientCreation:
     def test_client_lazy_initialization(self):
         """Test that the underlying client is created lazily."""
         config = LLMProfileConfig(
-            provider="anthropic", model="claude-3-5-haiku-20241022", api_key="test-key"
+            provider="anthropic", model="claude-haiku-4-5", api_key="test-key"
         )
 
         client = AnthropicClient(config)
@@ -119,7 +119,7 @@ class TestAnthropicClientCreation:
 
             # ChatAnthropic should only be called once
             mock_chat_anthropic.assert_called_once_with(
-                model="claude-3-5-haiku-20241022",
+                model="claude-haiku-4-5",
                 temperature=0.0,  # Default temperature
                 max_tokens=512,  # Default max_tokens (from config)
                 api_key="test-key",
@@ -153,7 +153,7 @@ class TestAnthropicClientCreation:
     def test_client_initialization_failure_raises_error(self):
         """Test that client initialization failure raises LLMProviderError."""
         config = LLMProfileConfig(
-            provider="anthropic", model="claude-3-5-haiku-20241022", api_key="test-key"
+            provider="anthropic", model="claude-haiku-4-5", api_key="test-key"
         )
 
         client = AnthropicClient(config)
@@ -170,11 +170,11 @@ class TestAnthropicClientCreation:
     def test_get_model_name(self):
         """Test get_model_name method returns correct model."""
         config = LLMProfileConfig(
-            provider="anthropic", model="claude-3-5-haiku-20241022", api_key="test-key"
+            provider="anthropic", model="claude-haiku-4-5", api_key="test-key"
         )
 
         client = AnthropicClient(config)
-        assert client.get_model_name() == "claude-3-5-haiku-20241022"
+        assert client.get_model_name() == "claude-haiku-4-5"
 
 
 class TestAnthropicClientInvoke:
@@ -183,7 +183,7 @@ class TestAnthropicClientInvoke:
     def setup_method(self):
         """Set up test fixtures."""
         self.config = LLMProfileConfig(
-            provider="anthropic", model="claude-3-5-haiku-20241022", api_key="test-key"
+            provider="anthropic", model="claude-haiku-4-5", api_key="test-key"
         )
         self.client = AnthropicClient(self.config)
 
@@ -297,7 +297,7 @@ class TestAnthropicClientErrorHandling:
     def test_error_message_classification(self):
         """Test that different error messages are classified correctly."""
         config = LLMProfileConfig(
-            provider="anthropic", model="claude-3-5-haiku-20241022", api_key="test-key"
+            provider="anthropic", model="claude-haiku-4-5", api_key="test-key"
         )
         client = AnthropicClient(config)
 
@@ -325,7 +325,7 @@ class TestAnthropicClientErrorHandling:
     def test_empty_messages_handling(self):
         """Test handling of empty messages list."""
         config = LLMProfileConfig(
-            provider="anthropic", model="claude-3-5-haiku-20241022", api_key="test-key"
+            provider="anthropic", model="claude-haiku-4-5", api_key="test-key"
         )
         client = AnthropicClient(config)
 
@@ -341,7 +341,7 @@ class TestAnthropicClientErrorHandling:
     def test_none_response_handling(self):
         """Test handling when underlying client returns None."""
         config = LLMProfileConfig(
-            provider="anthropic", model="claude-3-5-haiku-20241022", api_key="test-key"
+            provider="anthropic", model="claude-haiku-4-5", api_key="test-key"
         )
         client = AnthropicClient(config)
 
@@ -362,7 +362,7 @@ class TestAnthropicClientLogging:
     def test_debug_logging_during_initialization(self):
         """Test that debug logging occurs during client initialization."""
         config = LLMProfileConfig(
-            provider="anthropic", model="claude-3-5-haiku-20241022", api_key="test-key"
+            provider="anthropic", model="claude-haiku-4-5", api_key="test-key"
         )
         client = AnthropicClient(config)
 
@@ -374,13 +374,13 @@ class TestAnthropicClientLogging:
                 client._get_client()
 
                 mock_debug.assert_called_once_with(
-                    "Initialized Anthropic client with model: claude-3-5-haiku-20241022"
+                    "Initialized Anthropic client with model: claude-haiku-4-5"
                 )
 
     def test_logger_name_format(self):
         """Test that logger has correct name format."""
         config = LLMProfileConfig(
-            provider="anthropic", model="claude-3-5-haiku-20241022", api_key="test-key"
+            provider="anthropic", model="claude-haiku-4-5", api_key="test-key"
         )
         client = AnthropicClient(config)
 
@@ -394,7 +394,7 @@ class TestAnthropicClientIntegration:
     def test_multiple_invoke_calls_reuse_client(self):
         """Test that multiple invoke calls reuse the same underlying client."""
         config = LLMProfileConfig(
-            provider="anthropic", model="claude-3-5-haiku-20241022", api_key="test-key"
+            provider="anthropic", model="claude-haiku-4-5", api_key="test-key"
         )
         client = AnthropicClient(config)
 
@@ -417,7 +417,7 @@ class TestAnthropicClientIntegration:
         """Test a realistic conversation flow with multiple messages."""
         config = LLMProfileConfig(
             provider="anthropic",
-            model="claude-3-5-haiku-20241022",
+            model="claude-haiku-4-5",
             temperature=0.7,
             max_tokens=2000,
             api_key="test-key",
@@ -451,7 +451,7 @@ class TestAnthropicClientIntegration:
 
             # Verify client was created with correct parameters
             mock_chat_anthropic.assert_called_once_with(
-                model="claude-3-5-haiku-20241022",
+                model="claude-haiku-4-5",
                 temperature=0.7,
                 max_tokens=2000,
                 api_key="test-key",
@@ -465,7 +465,7 @@ class TestAnthropicClientSingleton:
         """Test that creating clients with identical configs returns the same instance."""
         config = LLMProfileConfig(
             provider="anthropic",
-            model="claude-3-5-haiku-20241022",
+            model="claude-haiku-4-5",
             temperature=0.7,
             max_tokens=1000,
             api_key="test-key",
@@ -482,7 +482,7 @@ class TestAnthropicClientSingleton:
         """Test that different configurations create different instances."""
         config1 = LLMProfileConfig(
             provider="anthropic",
-            model="claude-3-5-haiku-20241022",
+            model="claude-haiku-4-5",
             temperature=0.7,
             max_tokens=1000,
             api_key="test-key-1",
@@ -490,7 +490,7 @@ class TestAnthropicClientSingleton:
 
         config2 = LLMProfileConfig(
             provider="anthropic",
-            model="claude-3-5-haiku-20241022",
+            model="claude-haiku-4-5",
             temperature=0.5,  # Different temperature
             max_tokens=1000,
             api_key="test-key-1",
@@ -509,13 +509,13 @@ class TestAnthropicClientSingleton:
         """Test that different models create different instances."""
         config1 = LLMProfileConfig(
             provider="anthropic",
-            model="claude-3-5-haiku-20241022",
+            model="claude-haiku-4-5",
             api_key="test-key",
         )
 
         config2 = LLMProfileConfig(
             provider="anthropic",
-            model="claude-3-haiku-20240307",  # Different model
+            model="claude-haiku-4-5-20251001",  # Different model
             api_key="test-key",
         )
 
@@ -524,14 +524,14 @@ class TestAnthropicClientSingleton:
 
         # Should be different instances
         assert client1 is not client2
-        assert client1.get_model_name() == "claude-3-5-haiku-20241022"
-        assert client2.get_model_name() == "claude-3-haiku-20240307"
+        assert client1.get_model_name() == "claude-haiku-4-5"
+        assert client2.get_model_name() == "claude-haiku-4-5-20251001"
 
     def test_singleton_reload_functionality(self):
         """Test that reload_singleton creates a new instance."""
         config = LLMProfileConfig(
             provider="anthropic",
-            model="claude-3-5-haiku-20241022",
+            model="claude-haiku-4-5",
             api_key="test-key",
         )
 
@@ -552,7 +552,7 @@ class TestAnthropicClientSingleton:
         # Simulate the pattern used in schema_extraction_tool.py
         config = LLMProfileConfig(
             provider="anthropic",
-            model="claude-3-5-haiku-20241022",
+            model="claude-haiku-4-5",
             api_key="test-key",
         )
 

--- a/tests/unit/llm/test_factory.py
+++ b/tests/unit/llm/test_factory.py
@@ -44,7 +44,7 @@ class TestLLMClientFactory:
     def test_create_anthropic_client(self):
         """Test creating an Anthropic client through the factory."""
         config = LLMProfileConfig(
-            provider="anthropic", model="claude-3-5-haiku-20241022", api_key="test-key"
+            provider="anthropic", model="claude-haiku-4-5", api_key="test-key"
         )
 
         client = self.factory.create_client(config)
@@ -66,7 +66,7 @@ class TestLLMClientFactory:
     def test_create_client_singleton_behavior(self):
         """Test that factory respects singleton pattern of underlying clients."""
         config = LLMProfileConfig(
-            provider="anthropic", model="claude-3-5-haiku-20241022", api_key="test-key"
+            provider="anthropic", model="claude-haiku-4-5", api_key="test-key"
         )
 
         # Create two clients with same config
@@ -80,13 +80,13 @@ class TestLLMClientFactory:
         """Test that different configs create different client instances."""
         config1 = LLMProfileConfig(
             provider="anthropic",
-            model="claude-3-5-haiku-20241022",
+            model="claude-haiku-4-5",
             temperature=0.5,
             api_key="test-key",
         )
         config2 = LLMProfileConfig(
             provider="anthropic",
-            model="claude-3-5-haiku-20241022",
+            model="claude-haiku-4-5",
             temperature=0.7,  # Different temperature
             api_key="test-key",
         )
@@ -107,7 +107,7 @@ class TestLLMClientFactory:
         # Create config with mock values to bypass validation
         config = LLMProfileConfig(
             provider="anthropic",  # Valid provider for Pydantic
-            model="claude-3-5-haiku-20241022",
+            model="claude-haiku-4-5",
             api_key="test-key",
         )
         # Manually change provider to test factory validation
@@ -172,7 +172,7 @@ class TestLLMClientFactory:
                 # Create config with valid provider, then modify it
                 config = LLMProfileConfig(
                     provider="anthropic",  # Valid for Pydantic
-                    model="claude-3-5-haiku-20241022",
+                    model="claude-haiku-4-5",
                     api_key="test-key",
                 )
                 # Change to mock provider after validation
@@ -192,7 +192,7 @@ class TestLLMClientFactory:
 
         config = LLMProfileConfig(
             provider="anthropic",  # Valid for Pydantic
-            model="claude-3-5-haiku-20241022",
+            model="claude-haiku-4-5",
             api_key="test-key",
         )
         # Change to broken provider after validation
@@ -221,7 +221,7 @@ class TestLLMClientFactory:
 
         config = LLMProfileConfig(
             provider="anthropic",  # Valid for Pydantic
-            model="claude-3-5-haiku-20241022",
+            model="claude-haiku-4-5",
             api_key="test-key",
         )
         # Change to invalid provider after validation
@@ -237,12 +237,12 @@ class TestLLMClientFactory:
         """Test that provider names are handled case-insensitively in create_client."""
         config_upper = LLMProfileConfig(
             provider="ANTHROPIC",  # Uppercase
-            model="claude-3-5-haiku-20241022",
+            model="claude-haiku-4-5",
             api_key="test-key",
         )
         config_mixed = LLMProfileConfig(
             provider="Anthropic",  # Mixed case
-            model="claude-3-5-haiku-20241022",
+            model="claude-haiku-4-5",
             api_key="test-key",
         )
 
@@ -260,7 +260,7 @@ class TestConvenienceFunctions:
     def test_get_llm_client(self):
         """Test the get_llm_client convenience function."""
         config = LLMProfileConfig(
-            provider="anthropic", model="claude-3-5-haiku-20241022", api_key="test-key"
+            provider="anthropic", model="claude-haiku-4-5", api_key="test-key"
         )
 
         client = get_llm_client(config)
@@ -272,7 +272,7 @@ class TestConvenienceFunctions:
         """Test the get_llm_client_by_profile_name convenience function."""
         # Mock the config
         mock_profile = LLMProfileConfig(
-            provider="anthropic", model="claude-3-5-haiku-20241022", api_key="test-key"
+            provider="anthropic", model="claude-haiku-4-5", api_key="test-key"
         )
         mock_config.get_llm_profile.return_value = mock_profile
 
@@ -311,7 +311,7 @@ class TestFactoryIntegrationWithSingleton:
     def test_factory_and_direct_instantiation_same_instance(self):
         """Test that factory and direct instantiation return the same singleton instance."""
         config = LLMProfileConfig(
-            provider="anthropic", model="claude-3-5-haiku-20241022", api_key="test-key"
+            provider="anthropic", model="claude-haiku-4-5", api_key="test-key"
         )
 
         # Create via factory
@@ -327,7 +327,7 @@ class TestFactoryIntegrationWithSingleton:
     def test_multiple_factories_same_singletons(self):
         """Test that multiple factory instances respect singleton pattern."""
         config = LLMProfileConfig(
-            provider="anthropic", model="claude-3-5-haiku-20241022", api_key="test-key"
+            provider="anthropic", model="claude-haiku-4-5", api_key="test-key"
         )
 
         factory1 = LLMClientFactory()
@@ -366,7 +366,7 @@ class TestFactoryErrorScenarios:
 
         config = LLMProfileConfig(
             provider="anthropic",  # Valid for Pydantic
-            model="claude-3-5-haiku-20241022",
+            model="claude-haiku-4-5",
             api_key="test-key",
         )
         # Change to bad provider after validation
@@ -406,7 +406,7 @@ class TestFactoryErrorScenarios:
 
         config = LLMProfileConfig(
             provider="anthropic",  # Valid for Pydantic
-            model="claude-3-5-haiku-20241022",
+            model="claude-haiku-4-5",
             api_key="test-key",
         )
         # Change to failing provider after validation


### PR DESCRIPTION
## Summary
- Replace retired `claude-3-5-haiku-20241022` model with `claude-haiku-4-5` across the codebase
- Update the `VALID_MODELS` whitelist in `src/config/models.py` to reflect current Anthropic model offerings (`claude-haiku-4-5`, `claude-sonnet-4-6`, `claude-opus-4-7`)
- Update all test fixtures, docs, and docstrings referencing the old model IDs

## Context
The Anthropic API returns a `404 Not Found` for `claude-3-5-haiku-20241022` because the model has been retired. This broke the job evaluation extraction workflow entirely.

## Test plan
- [x] All 314 unit tests pass
- [x] Manually verified the app works with the new model