### PR TITLE
feat(job-evaluation): add user preferences and enhanced evaluation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,6 +129,9 @@ Thumbs.db
 # Add any project specific files to ignore here
 job_search_assistant.txt
 
+# Locally persisted user preferences (user-specific runtime data)
+data/user_preferences.yaml
+
 # Local logs directory (ignored to keep repo clean)
 logs/
 

--- a/configs/base.toml
+++ b/configs/base.toml
@@ -26,9 +26,9 @@ max_tokens = 512
 
 [llm_profiles.google_job_evaluation]
 provider = "google"
-model = "gemini-3.5-flash"
+model = "gemini-2.5-flash"
 temperature = 0.0
-max_tokens = 512
+max_tokens = 4096
 
 [llm_profiles.google_interview_research]
 provider = "google"

--- a/configs/base.toml
+++ b/configs/base.toml
@@ -51,16 +51,11 @@ max_tokens = 4096
 # Agent task to LLM profile mapping
 [agents]
 job_evaluation_extraction = "anthropic_extraction"
+job_evaluation_fit = "anthropic_extraction"
 interview_research = "google_flash_lite"
 interview_question_generation = "google_flash_lite"
 interview_answer_generation = "google_flash_lite"
 interview_compilation = "google_flash_lite"
-
-# Business logic parameters for job evaluation
-[evaluation_criteria]
-min_salary = 100000
-remote_required = true
-ic_title_requirements = ["lead", "staff", "principal", "senior staff"]
 
 [observability.langfuse]
 enabled = false

--- a/configs/base.toml
+++ b/configs/base.toml
@@ -24,6 +24,12 @@ model = "gemini-2.5-flash"
 temperature = 0.0
 max_tokens = 512
 
+[llm_profiles.google_job_evaluation]
+provider = "google"
+model = "gemini-3.5-flash"
+temperature = 0.0
+max_tokens = 512
+
 [llm_profiles.google_interview_research]
 provider = "google"
 model = "gemini-2.5-pro"
@@ -50,8 +56,8 @@ max_tokens = 4096
 
 # Agent task to LLM profile mapping
 [agents]
-job_evaluation_extraction = "anthropic_extraction"
-job_evaluation_fit = "anthropic_extraction"
+job_evaluation_extraction = "google_job_evaluation"
+job_evaluation_fit = "google_job_evaluation"
 interview_research = "google_flash_lite"
 interview_question_generation = "google_flash_lite"
 interview_answer_generation = "google_flash_lite"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "presidio-analyzer>=2.2.362",
     "presidio-anonymizer>=2.2.362",
     "langchain-tavily>=0.2.18",
+    "pyyaml>=6.0.3",
 ]
 
 [project.optional-dependencies]

--- a/src/agent/prompts/evaluation/__init__.py
+++ b/src/agent/prompts/evaluation/__init__.py
@@ -1,0 +1,6 @@
+"""
+Evaluation prompt templates.
+
+Prompt templates used by the job evaluation workflow, such as the LLM-based
+fit assessment.
+"""

--- a/src/agent/prompts/evaluation/fit.py
+++ b/src/agent/prompts/evaluation/fit.py
@@ -18,8 +18,8 @@ their full background; that decision is made elsewhere).
 Compare the candidate's target role and key skills against the job's actual
 focus areas, responsibilities, and required skills. Do not rely on the job
 title alone -- a similar title with a different focus may still be a poor match
-(for example, an "AI Engineer" who builds LLM/RAG systems is a poor match for a
-"Data Scientist" role centered on A/B testing and recommendation engines).
+(for example, a "Data Scientist" who builds LLM-driven applications is a poor
+match for a "Data Scientist" role focused on A/B testing and analytics).
 
 Return:
 - verdict: "good_fit" if the role's focus matches the candidate's target role

--- a/src/agent/prompts/evaluation/fit.py
+++ b/src/agent/prompts/evaluation/fit.py
@@ -1,27 +1,31 @@
 """
 Fit assessment prompt for structured outputs.
 
-Guides the LLM to judge whether a job posting is a good fit for the user's
-target role and skills, based on the actual focus areas and responsibilities of
-the role rather than the title alone.
+Guides the LLM to judge whether a job's focus (responsibilities, required
+skills, domain) matches the user's target role and skills -- strictly a
+subject-matter alignment judgment, not a hiring-likelihood one -- based on the
+role's actual focus areas rather than the title alone.
 """
 
 from langchain_core.prompts import PromptTemplate
 
 FIT_ASSESSMENT_RAW_TEMPLATE = """
-You are assessing whether a job posting is a good fit for a candidate.
+You are judging whether a job's focus matches a candidate's target role and
+skills. Judge only the alignment of subject matter -- do NOT speculate about
+whether the candidate would get hired or be a strong applicant (you do not have
+their full background; that decision is made elsewhere).
 
 Compare the candidate's target role and key skills against the job's actual
 focus areas, responsibilities, and required skills. Do not rely on the job
-title alone -- a similar title with a different focus may still be a poor fit
-(for example, an "AI Engineer" who builds LLM/RAG systems is a poor fit for a
+title alone -- a similar title with a different focus may still be a poor match
+(for example, an "AI Engineer" who builds LLM/RAG systems is a poor match for a
 "Data Scientist" role centered on A/B testing and recommendation engines).
 
 Return:
-- verdict: "good_fit" if the candidate's profile aligns well with the role's
-  focus and the candidate would likely be a strong applicant; otherwise
-  "poor_fit".
-- reasoning: one or two sentences explaining the verdict.
+- verdict: "good_fit" if the role's focus matches the candidate's target role
+  and skills; otherwise "poor_fit".
+- reasoning: one or two sentences explaining the verdict, referring only to
+  subject-matter alignment.
 
 Candidate's target role:
 {target_role_description}

--- a/src/agent/prompts/evaluation/fit.py
+++ b/src/agent/prompts/evaluation/fit.py
@@ -1,0 +1,36 @@
+"""
+Fit assessment prompt for structured outputs.
+
+Guides the LLM to judge whether a job posting is a good fit for the user's
+target role and skills, based on the actual focus areas and responsibilities of
+the role rather than the title alone.
+"""
+
+from langchain_core.prompts import PromptTemplate
+
+FIT_ASSESSMENT_RAW_TEMPLATE = """
+You are assessing whether a job posting is a good fit for a candidate.
+
+Compare the candidate's target role and key skills against the job's actual
+focus areas, responsibilities, and required skills. Do not rely on the job
+title alone -- a similar title with a different focus may still be a poor fit
+(for example, an "AI Engineer" who builds LLM/RAG systems is a poor fit for a
+"Data Scientist" role centered on A/B testing and recommendation engines).
+
+Return:
+- verdict: "good_fit" if the candidate's profile aligns well with the role's
+  focus and the candidate would likely be a strong applicant; otherwise
+  "poor_fit".
+- reasoning: one or two sentences explaining the verdict.
+
+Candidate's target role:
+{target_role_description}
+
+Candidate's key skills:
+{key_skills}
+
+Job posting:
+{job_text}
+"""
+
+FIT_ASSESSMENT_PROMPT = PromptTemplate.from_template(FIT_ASSESSMENT_RAW_TEMPLATE)

--- a/src/agent/prompts/extraction/job_posting.py
+++ b/src/agent/prompts/extraction/job_posting.py
@@ -8,7 +8,32 @@ focusing on clear instructions without JSON formatting requirements.
 from langchain_core.prompts import PromptTemplate
 
 JOB_POSTING_EXTRACTION_RAW_TEMPLATE = """
-Extract structured information from this job posting:
+Extract structured information from this job posting.
+
+Follow these rules:
+- Salary: report annual amounts in USD. If the posting lists multiple salary
+  ranges (for example, different ranges per location or level), extract the
+  HIGHEST range. `salary_min` and `salary_max` must reflect that top-paying
+  range.
+- seniority_level: infer from the title and responsibilities (junior, mid,
+  senior, staff, principal, lead). Use "unclear" if it cannot be determined.
+- visa_sponsorship: "yes" if the posting states sponsorship is available, "no"
+  if it states sponsorship is not available, otherwise "unclear".
+- employment_type: full-time, part-time, contract, or internship; "unclear" if
+  not stated.
+- travel_required: "yes" if the role requires travel, "no" if it states no
+  travel, otherwise "unclear".
+- education_requirement: the MINIMUM degree required (associate, bachelor,
+  master, phd). Use "none" only if the posting explicitly says no degree is
+  required, and "unclear" if education is not mentioned.
+- equity_offered: list any equity types mentioned (stock_options, rsus). Leave
+  empty if equity is not mentioned.
+- benefits_offered: list any benefits mentioned (health, vision, dental, life,
+  std, ltd, 401k, pto). Leave empty if benefits are not mentioned.
+- For any field not mentioned in the posting, use its default ("unclear" or an
+  empty list) rather than guessing.
+
+Job posting:
 
 {job_text}
 """

--- a/src/agent/workflows/job_evaluation/main.py
+++ b/src/agent/workflows/job_evaluation/main.py
@@ -15,13 +15,27 @@ from src.agent.tools.extraction.schema_extraction_tool import (
 )
 from src.agent.workflows.job_evaluation.states import JobEvaluationState
 from src.core.job_evaluation import (
+    evaluate_fit,
     evaluate_job_against_criteria,
     generate_recommendation_from_evaluation,
 )
+from src.core.preferences import load_preferences
 from src.llm import langfuse_manager
+from src.models.user import JobPreferences
 from src.utils.logging import get_logger
+from src.utils.text import MAX_JOB_DESCRIPTION_CHARS, truncate_text
 
 logger = get_logger(__name__)
+
+
+def load_user_preferences(state: JobEvaluationState) -> Dict[str, Any]:
+    """Load user preferences so they are available to downstream nodes."""
+    logger.info("Loading user preferences")
+
+    if state.user_preferences is not None:
+        return {}
+
+    return {"user_preferences": load_preferences()}
 
 
 def validate_input(state: JobEvaluationState) -> Dict[str, Any]:
@@ -47,7 +61,9 @@ def extract_job_info(state: JobEvaluationState) -> Dict[str, Any]:
     """Extract structured information from job posting text."""
     logger.info("Extracting job information")
 
-    job_text = state.job_posting_text
+    job_text = truncate_text(
+        state.job_posting_text, MAX_JOB_DESCRIPTION_CHARS, "job posting"
+    )
 
     try:
         extracted_info = extract_job_posting(job_text)
@@ -75,7 +91,7 @@ def extract_job_info(state: JobEvaluationState) -> Dict[str, Any]:
 
 
 def evaluate_job(state: JobEvaluationState) -> Dict[str, Any]:
-    """Evaluate extracted job information against criteria."""
+    """Evaluate extracted job information against user preferences."""
     logger.info("Evaluating job against criteria")
 
     extracted_info = state.extracted_info
@@ -88,8 +104,13 @@ def evaluate_job(state: JobEvaluationState) -> Dict[str, Any]:
             "reasoning": "No job information available for evaluation",
         }
 
+    preferences = state.user_preferences or JobPreferences()
+
     try:
-        evaluation_result = evaluate_job_against_criteria(extracted_info)
+        evaluation_result = evaluate_job_against_criteria(extracted_info, preferences)
+
+        # Fold in the LLM-based fit assessment as an additional criterion.
+        evaluation_result["fit"] = evaluate_fit(state.job_posting_text, preferences)
 
         logger.info("Job evaluation completed successfully")
         return {"evaluation_result": evaluation_result}
@@ -160,12 +181,14 @@ def get_job_evaluation_workflow() -> StateGraph:
 
         workflow = StateGraph(JobEvaluationState)
 
+        workflow.add_node("load_preferences", load_user_preferences)
         workflow.add_node("validate", validate_input)
         workflow.add_node("extract", extract_job_info)
         workflow.add_node("evaluate", evaluate_job)
         workflow.add_node("recommend", generate_recommendation)
 
-        workflow.add_edge(START, "validate")
+        workflow.add_edge(START, "load_preferences")
+        workflow.add_edge("load_preferences", "validate")
         workflow.add_conditional_edges(
             "validate", _route_on_error, {"continue": "extract", END: END}
         )

--- a/src/agent/workflows/job_evaluation/main.py
+++ b/src/agent/workflows/job_evaluation/main.py
@@ -110,6 +110,8 @@ def evaluate_job(state: JobEvaluationState) -> Dict[str, Any]:
         evaluation_result = evaluate_job_against_criteria(extracted_info, preferences)
 
         # Fold in the LLM-based fit assessment as an additional criterion.
+        # evaluate_fit never raises (it falls back to its none policy on any
+        # failure), so a fit problem cannot discard the rule-based results here.
         evaluation_result["fit"] = evaluate_fit(state.job_posting_text, preferences)
 
         logger.info("Job evaluation completed successfully")

--- a/src/agent/workflows/job_evaluation/main.py
+++ b/src/agent/workflows/job_evaluation/main.py
@@ -54,19 +54,19 @@ def validate_input(state: JobEvaluationState) -> Dict[str, Any]:
         }
 
     logger.info("Job posting input validation passed")
-    return {}
+    # Bound the posting text once here so every downstream node (extraction and
+    # fit) works from the same truncated text and the warning is logged once.
+    bounded_text = truncate_text(job_text, MAX_JOB_DESCRIPTION_CHARS, "job posting")
+    return {"job_posting_text": bounded_text}
 
 
 def extract_job_info(state: JobEvaluationState) -> Dict[str, Any]:
     """Extract structured information from job posting text."""
     logger.info("Extracting job information")
 
-    job_text = truncate_text(
-        state.job_posting_text, MAX_JOB_DESCRIPTION_CHARS, "job posting"
-    )
-
+    # Text was already bounded in validate_input.
     try:
-        extracted_info = extract_job_posting(job_text)
+        extracted_info = extract_job_posting(state.job_posting_text)
 
         is_valid = validate_extraction_result(extracted_info, "job_posting")
 

--- a/src/agent/workflows/job_evaluation/main.py
+++ b/src/agent/workflows/job_evaluation/main.py
@@ -188,7 +188,12 @@ def get_job_evaluation_workflow() -> StateGraph:
         workflow.add_node("recommend", generate_recommendation)
 
         workflow.add_edge(START, "load_preferences")
-        workflow.add_edge("load_preferences", "validate")
+        # Every node routes through _route_on_error so the graph stays uniform:
+        # if any node (now or in the future) sets recommendation="ERROR" the
+        # workflow short-circuits to END.
+        workflow.add_conditional_edges(
+            "load_preferences", _route_on_error, {"continue": "validate", END: END}
+        )
         workflow.add_conditional_edges(
             "validate", _route_on_error, {"continue": "extract", END: END}
         )

--- a/src/agent/workflows/job_evaluation/states.py
+++ b/src/agent/workflows/job_evaluation/states.py
@@ -9,6 +9,8 @@ from typing import Any, Dict, Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from src.models.user import JobPreferences
+
 
 class JobEvaluationState(BaseModel):
     """State for job evaluation workflow with validation."""
@@ -24,6 +26,11 @@ class JobEvaluationState(BaseModel):
     # Input - allow empty strings and None for proper error handling
     job_posting_text: Optional[str] = Field(
         default="", description="The job posting text to evaluate"
+    )
+
+    # User preferences loaded at the start of the workflow
+    user_preferences: Optional[JobPreferences] = Field(
+        default=None, description="User job-search preferences for evaluation"
     )
 
     # Intermediate results

--- a/src/config/models.py
+++ b/src/config/models.py
@@ -6,7 +6,7 @@ sections in the application.
 """
 
 import os
-from typing import ClassVar, Dict, List, Optional
+from typing import ClassVar, Dict, Optional
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -48,6 +48,10 @@ class AgentConfig(BaseModel):
     job_evaluation_extraction: str = Field(
         ..., description="LLM profile for job information extraction"
     )
+    job_evaluation_fit: str = Field(
+        default="anthropic_extraction",
+        description="LLM profile for the job fit assessment",
+    )
 
     # New interview preparation agents
     interview_research: str = Field(
@@ -65,16 +69,6 @@ class AgentConfig(BaseModel):
     interview_compilation: str = Field(
         default="google_interview_generation",
         description="LLM profile for guide compilation",
-    )
-
-
-class EvaluationCriteriaConfig(BaseModel):
-    """Business logic parameters for job evaluation."""
-
-    min_salary: int = Field(..., ge=0, description="Minimum acceptable salary")
-    remote_required: bool = Field(..., description="Whether remote work is required")
-    ic_title_requirements: List[str] = Field(
-        ..., description="Required seniority levels for IC roles"
     )
 
 
@@ -221,9 +215,6 @@ class AppConfig(BaseModel):
     general: GeneralConfig = Field(..., description="General application configuration")
     logging: LoggingConfig = Field(..., description="Logging configuration")
     agents: AgentConfig = Field(..., description="Agent configuration")
-    evaluation_criteria: EvaluationCriteriaConfig = Field(
-        ..., description="Job evaluation criteria"
-    )
     llm_profiles: Dict[str, LLMProfileConfig] = Field(
         ..., description="LLM profile configurations"
     )

--- a/src/config/models.py
+++ b/src/config/models.py
@@ -49,7 +49,7 @@ class AgentConfig(BaseModel):
         ..., description="LLM profile for job information extraction"
     )
     job_evaluation_fit: str = Field(
-        default="anthropic_extraction",
+        default="google_job_evaluation",
         description="LLM profile for the job fit assessment",
     )
 
@@ -95,6 +95,7 @@ class LLMProfileConfig(BaseModel):
             "claude-opus-4-7",
         },
         "google": {
+            "gemini-3.5-flash",
             "gemini-2.5-pro",
             "gemini-2.5-flash",
             "gemini-2.5-flash-lite",

--- a/src/core/job_evaluation/__init__.py
+++ b/src/core/job_evaluation/__init__.py
@@ -6,6 +6,12 @@ configuration system for evaluation criteria.
 """
 
 from src.core.job_evaluation.evaluator import evaluate_job_against_criteria
+from src.core.job_evaluation.fit_evaluator import FitAssessment, evaluate_fit
 from src.core.job_evaluation.recommender import generate_recommendation_from_evaluation
 
-__all__ = ["evaluate_job_against_criteria", "generate_recommendation_from_evaluation"]
+__all__ = [
+    "evaluate_job_against_criteria",
+    "evaluate_fit",
+    "FitAssessment",
+    "generate_recommendation_from_evaluation",
+]

--- a/src/core/job_evaluation/evaluator.py
+++ b/src/core/job_evaluation/evaluator.py
@@ -1,126 +1,305 @@
 """
-Job evaluation core logic
+Job evaluation core logic.
 
-This module contains the core business logic for evaluating job postings
-against user-defined criteria. It's designed to be framework-agnostic
-and reusable across different contexts.
+Evaluates extracted job information against a user's :class:`JobPreferences`.
+Each criterion produces a result dict with a uniform shape::
+
+    {
+        "pass": bool,
+        "reason": str,
+        "mode": "required" | "optional",
+        "extracted_value": Any | None,
+    }
+
+This module covers the rule-based criteria only. The LLM-based "fit" criterion
+lives in :mod:`src.core.job_evaluation.fit_evaluator` and is folded into the
+results by the workflow.
 """
 
-from typing import Any, Dict
+import re
+from typing import Any, Dict, List, Optional
 
-from src.config import config
+from src.models.user import CriterionConfig, JobPreferences, NonePolicy
 from src.utils.logging import get_logger
 
 logger = get_logger(__name__)
 
+# Ordinal ranking for education levels (higher = more advanced).
+_EDUCATION_RANK = {"associate": 1, "bachelor": 2, "master": 3, "phd": 4}
 
-def evaluate_job_against_criteria(extracted_job_info: Dict[str, Any]) -> Dict[str, Any]:
+
+def _result(
+    passed: bool, reason: str, config: CriterionConfig, extracted_value: Any
+) -> Dict[str, Any]:
+    """Build a uniform criterion result dict."""
+    return {
+        "pass": passed,
+        "reason": reason,
+        "mode": config.mode.value,
+        "extracted_value": extracted_value,
+    }
+
+
+def _none_result(
+    config: CriterionConfig, extracted_value: Any, label: str
+) -> Dict[str, Any]:
+    """Build a result for a criterion whose data is missing from the posting."""
+    passed = config.none_policy == NonePolicy.PASS
+    decision = "pass" if passed else "fail"
+    reason = f"{label} not specified in posting; counted as {decision} per preference"
+    return _result(passed, reason, config, extracted_value)
+
+
+def _words(text: str) -> set:
+    """Tokenize ``text`` into a set of lowercase alphanumeric words."""
+    return set(re.findall(r"[a-z0-9]+", text.lower()))
+
+
+def _find_blacklist_match(company: str, blacklist: List[str]) -> Optional[str]:
+    """Return the blacklist entry that matches ``company``, if any.
+
+    Uses word-boundary-aware normalized matching: every word in a blacklist
+    entry must appear as a word in the company name. So "Microsoft" matches
+    "Microsoft Co. Ltd." but "Meta" does not match "Metadata Inc.".
     """
-    Evaluate extracted job information against evaluation criteria.
+    company_words = _words(company)
+    for entry in blacklist:
+        entry_words = _words(entry)
+        if entry_words and entry_words.issubset(company_words):
+            return entry
+    return None
 
-    This function contains the core business logic for job evaluation,
-    independent of any specific workflow or state management framework.
+
+def _evaluate_salary(info: Dict[str, Any], prefs: JobPreferences) -> Dict[str, Any]:
+    config = prefs.salary_config
+    salary_max = info.get("salary_max")
+    if salary_max is None:
+        return _none_result(config, None, "Salary")
+
+    if salary_max >= prefs.min_salary:
+        reason = (
+            f"Top-of-range salary (${salary_max:,}) meets minimum "
+            f"(${prefs.min_salary:,})"
+        )
+        return _result(True, reason, config, salary_max)
+
+    reason = (
+        f"Top-of-range salary (${salary_max:,}) is below minimum "
+        f"(${prefs.min_salary:,})"
+    )
+    return _result(False, reason, config, salary_max)
+
+
+def _evaluate_membership(
+    value: Optional[str],
+    acceptable: List[str],
+    config: CriterionConfig,
+    label: str,
+    unclear_value: str = "unclear",
+) -> Dict[str, Any]:
+    """Generic check: extracted ``value`` must be in ``acceptable``."""
+    if not value or value == unclear_value:
+        return _none_result(config, value, label)
+
+    normalized = value.strip().lower()
+    if normalized in acceptable:
+        return _result(True, f"{label} '{value}' is acceptable", config, value)
+    return _result(
+        False,
+        f"{label} '{value}' is not in acceptable list ({', '.join(acceptable)})",
+        config,
+        value,
+    )
+
+
+def _evaluate_visa(info: Dict[str, Any], prefs: JobPreferences) -> Dict[str, Any]:
+    config = prefs.visa_config
+    value = info.get("visa_sponsorship", "unclear")
+
+    if not prefs.visa_sponsorship_required:
+        return _result(True, "Visa sponsorship not required by user", config, value)
+
+    if value == "unclear":
+        return _none_result(config, value, "Visa sponsorship")
+
+    if value == "yes":
+        return _result(True, "Posting offers visa sponsorship", config, value)
+    return _result(False, "Posting does not offer visa sponsorship", config, value)
+
+
+def _evaluate_blacklist(info: Dict[str, Any], prefs: JobPreferences) -> Dict[str, Any]:
+    config = prefs.blacklist_config
+    company = info.get("company")
+
+    if not prefs.company_blacklist:
+        return _result(True, "No companies blacklisted", config, company)
+
+    if not company or not str(company).strip():
+        return _none_result(config, company, "Company")
+
+    match = _find_blacklist_match(str(company), prefs.company_blacklist)
+    if match is not None:
+        return _result(
+            False,
+            f"Company '{company}' matches blacklist entry '{match}'",
+            config,
+            company,
+        )
+    return _result(True, f"Company '{company}' is not blacklisted", config, company)
+
+
+def _evaluate_travel(info: Dict[str, Any], prefs: JobPreferences) -> Dict[str, Any]:
+    config = prefs.travel_config
+    value = info.get("travel_required", "unclear")
+
+    if prefs.willing_to_travel:
+        return _result(True, "User is willing to travel", config, value)
+
+    if value == "unclear":
+        return _none_result(config, value, "Travel requirement")
+
+    if value == "yes":
+        return _result(
+            False, "Role requires travel but user is not willing", config, value
+        )
+    return _result(True, "Role does not require travel", config, value)
+
+
+def _evaluate_education(info: Dict[str, Any], prefs: JobPreferences) -> Dict[str, Any]:
+    config = prefs.education_config
+    value = info.get("education_requirement", "unclear")
+
+    if value == "unclear":
+        return _none_result(config, value, "Education requirement")
+
+    if value == "none":
+        return _result(True, "Posting requires no specific degree", config, value)
+
+    required_rank = _EDUCATION_RANK.get(value)
+    user_rank = _EDUCATION_RANK.get(prefs.education_level, 0)
+    if required_rank is None:
+        return _none_result(config, value, "Education requirement")
+
+    if user_rank >= required_rank:
+        return _result(
+            True,
+            f"User education ({prefs.education_level}) meets requirement ({value})",
+            config,
+            value,
+        )
+    return _result(
+        False,
+        f"User education ({prefs.education_level}) is below requirement ({value})",
+        config,
+        value,
+    )
+
+
+def _evaluate_equity(info: Dict[str, Any], prefs: JobPreferences) -> Dict[str, Any]:
+    config = prefs.equity_config
+    offered = info.get("equity_offered") or []
+
+    if not prefs.acceptable_equity_types:
+        return _result(True, "No equity preference set", config, offered)
+
+    if not offered:
+        return _none_result(config, offered, "Equity")
+
+    overlap = [e for e in prefs.acceptable_equity_types if e in offered]
+    if overlap:
+        return _result(
+            True,
+            f"Posting offers acceptable equity ({', '.join(overlap)})",
+            config,
+            offered,
+        )
+    return _result(
+        False,
+        f"Posting equity ({', '.join(offered)}) does not match preference",
+        config,
+        offered,
+    )
+
+
+def _evaluate_benefits(info: Dict[str, Any], prefs: JobPreferences) -> Dict[str, Any]:
+    config = prefs.benefits_config
+    offered = info.get("benefits_offered") or []
+
+    if not prefs.required_benefits:
+        return _result(True, "No benefits preference set", config, offered)
+
+    if not offered:
+        return _none_result(config, offered, "Benefits")
+
+    missing = [b for b in prefs.required_benefits if b not in offered]
+    if not missing:
+        return _result(True, "Posting offers all required benefits", config, offered)
+    return _result(
+        False,
+        f"Posting is missing required benefits ({', '.join(missing)})",
+        config,
+        offered,
+    )
+
+
+def evaluate_job_against_criteria(
+    extracted_job_info: Dict[str, Any], preferences: JobPreferences
+) -> Dict[str, Any]:
+    """Evaluate extracted job information against user preferences.
 
     Args:
-        extracted_job_info: Dictionary containing parsed job details
+        extracted_job_info: Parsed job details (from the extraction schema).
+        preferences: The user's job-search preferences.
 
     Returns:
-        Dictionary with evaluation results for each criteria
+        A dict mapping each rule-based criterion name to its result dict. The
+        "fit" criterion is added separately by the workflow.
     """
     if not extracted_job_info:
         logger.warning("No extracted job information provided for evaluation")
         return {"error": "No extracted information available"}
 
-    logger.info("Starting job evaluation against criteria")
-    results = {}
+    logger.info("Starting job evaluation against user preferences")
 
-    # Get evaluation criteria from centralized config
-    criteria = config.evaluation_criteria
+    results: Dict[str, Any] = {
+        "salary": _evaluate_salary(extracted_job_info, preferences),
+        "location": _evaluate_membership(
+            extracted_job_info.get("location_policy"),
+            preferences.acceptable_locations,
+            preferences.location_config,
+            "Location policy",
+        ),
+        "level": _evaluate_membership(
+            extracted_job_info.get("role_type"),
+            preferences.acceptable_levels,
+            preferences.level_config,
+            "Role type",
+        ),
+        "seniority": _evaluate_membership(
+            extracted_job_info.get("seniority_level"),
+            preferences.acceptable_seniority,
+            preferences.seniority_config,
+            "Seniority level",
+        ),
+        "visa": _evaluate_visa(extracted_job_info, preferences),
+        "blacklist": _evaluate_blacklist(extracted_job_info, preferences),
+        "employment_type": _evaluate_membership(
+            extracted_job_info.get("employment_type"),
+            preferences.acceptable_employment_types,
+            preferences.employment_type_config,
+            "Employment type",
+        ),
+        "travel": _evaluate_travel(extracted_job_info, preferences),
+        "education": _evaluate_education(extracted_job_info, preferences),
+        "equity": _evaluate_equity(extracted_job_info, preferences),
+        "benefits": _evaluate_benefits(extracted_job_info, preferences),
+    }
 
-    # 1. Salary check
-    salary_max = extracted_job_info.get("salary_max")
-    if salary_max is None:
-        results["salary"] = {"pass": False, "reason": "Salary not specified"}
-        logger.debug("Salary evaluation: Failed - not specified")
-    elif salary_max < criteria.min_salary:
-        min_salary = criteria.min_salary
-        results["salary"] = {
-            "pass": False,
-            "reason": (
-                f"Highest salary (${salary_max:,}) is lower than required "
-                f"salary (${min_salary:,})"
-            ),
-        }
-        logger.debug(f"Salary evaluation: Failed - ${salary_max:,} < ${min_salary:,}")
-    else:
-        min_salary = criteria.min_salary
-        results["salary"] = {
-            "pass": True,
-            "reason": (
-                f"Salary (${salary_max:,}) meets minimum requirement "
-                f"(${min_salary:,})"
-            ),
-        }
-        logger.debug(f"Salary evaluation: Passed - ${salary_max:,} >= ${min_salary:,}")
-
-    # 2. Remote policy check
-    location_policy = extracted_job_info.get("location_policy", "").lower()
-    if "remote" in location_policy:
-        results["remote"] = {"pass": True, "reason": "Position is remote"}
-        logger.debug("Remote policy evaluation: Passed - position is remote")
-    else:
-        results["remote"] = {
-            "pass": False,
-            "reason": f"Position is not remote (location policy: {location_policy})",
-        }
-        logger.debug(
-            f"Remote policy evaluation: Failed - location policy: {location_policy}"
-        )
-
-    # 3. IC title level check (only for IC roles)
-    role_type = extracted_job_info.get("role_type", "").lower()
-    title = extracted_job_info.get("title", "").lower()
-
-    if "ic" in role_type or "individual contributor" in role_type:
-        # Check if title contains required seniority level
-        ic_requirements = criteria.ic_title_requirements
-        has_required_level = any(level in title for level in ic_requirements)
-        if has_required_level:
-            results["title_level"] = {
-                "pass": True,
-                "reason": "IC role has appropriate seniority level",
-            }
-            logger.debug(
-                "Title level evaluation: Passed - IC role has appropriate seniority"
-            )
-        else:
-            required_levels = ", ".join(ic_requirements)
-            results["title_level"] = {
-                "pass": False,
-                "reason": (
-                    f"IC role lacks required seniority (needs: {required_levels})"
-                ),
-            }
-            logger.debug(
-                f"Title level evaluation: Failed - IC role lacks seniority. Title: {title}"
-            )
-    else:
-        # Not an IC role, so title level requirement doesn't apply
-        results["title_level"] = {
-            "pass": True,
-            "reason": "Title level requirement not applicable (not IC role)",
-        }
-        logger.debug("Title level evaluation: Passed - not an IC role")
-
-    passed_count = sum(
-        1
-        for result in results.values()
-        if isinstance(result, dict) and result.get("pass", False)
-    )
-    total_count = len([r for r in results.values() if isinstance(r, dict)])
-
+    passed_count = sum(1 for r in results.values() if r.get("pass"))
     logger.info(
-        f"Job evaluation completed: {passed_count}/{total_count} criteria passed"
+        "Job evaluation completed: %d/%d criteria passed",
+        passed_count,
+        len(results),
     )
 
     return results

--- a/src/core/job_evaluation/evaluator.py
+++ b/src/core/job_evaluation/evaluator.py
@@ -202,6 +202,11 @@ def _evaluate_equity(info: Dict[str, Any], prefs: JobPreferences) -> Dict[str, A
     if not prefs.acceptable_equity_types:
         return _result(True, "No equity preference set", config, offered)
 
+    # Limitation: the extraction schema defaults equity_offered to [] both when
+    # the posting omits equity and when it explicitly states none, so the two
+    # are indistinguishable here. Both are treated as "missing" and follow the
+    # none policy rather than failing outright. Extracting a tri-state
+    # (unclear/none/list) would be needed to tell them apart.
     if not offered:
         return _none_result(config, offered, "Equity")
 
@@ -228,6 +233,9 @@ def _evaluate_benefits(info: Dict[str, Any], prefs: JobPreferences) -> Dict[str,
     if not prefs.required_benefits:
         return _result(True, "No benefits preference set", config, offered)
 
+    # Same limitation as equity: an empty benefits_offered list conflates "not
+    # mentioned" with "explicitly none", so both follow the none policy rather
+    # than failing outright.
     if not offered:
         return _none_result(config, offered, "Benefits")
 

--- a/src/core/job_evaluation/fit_evaluator.py
+++ b/src/core/job_evaluation/fit_evaluator.py
@@ -87,9 +87,19 @@ def evaluate_fit(job_posting_text: str, preferences: JobPreferences) -> Dict[str
 
     config_dict = langfuse_manager.get_config()
     logger.info("Assessing job fit via LLM")
-    assessment: FitAssessment = structured_llm.invoke(
-        [HumanMessage(content=prompt_content)], config=config_dict
-    )
+    try:
+        assessment: FitAssessment = structured_llm.invoke(
+            [HumanMessage(content=prompt_content)], config=config_dict
+        )
+    except Exception as e:
+        # Fit is one of many criteria. A transient LLM failure (network, rate
+        # limit, structured-output parse error) must not discard the
+        # rule-based results, so fall back to the none policy.
+        passed = fit_config.none_policy == NonePolicy.PASS
+        decision = "pass" if passed else "fail"
+        reason = f"Fit assessment failed ({e}); counted as {decision} per preference"
+        logger.warning("Fit assessment failed: %s", e)
+        return _result(passed, reason, fit_config, None)
 
     passed = assessment.verdict == "good_fit"
     return _result(passed, assessment.reasoning, fit_config, assessment.verdict)

--- a/src/core/job_evaluation/fit_evaluator.py
+++ b/src/core/job_evaluation/fit_evaluator.py
@@ -1,0 +1,95 @@
+"""
+LLM-based fit assessment.
+
+Unlike the rule-based criteria in :mod:`src.core.job_evaluation.evaluator`,
+this criterion uses an LLM to judge semantic alignment between the user's
+target role/skills and the job's actual focus.
+"""
+
+from typing import Any, Dict, Literal
+
+from langchain_core.messages import HumanMessage
+from pydantic import BaseModel, Field
+
+from src.agent.prompts.evaluation.fit import FIT_ASSESSMENT_PROMPT
+from src.config import config
+from src.llm import get_chat_model_by_profile_name, langfuse_manager
+from src.models.user import JobPreferences, NonePolicy
+from src.utils.logging import get_logger
+from src.utils.text import (
+    MAX_JOB_DESCRIPTION_CHARS,
+    MAX_ROLE_DESCRIPTION_CHARS,
+    truncate_text,
+)
+
+logger = get_logger(__name__)
+
+
+class FitAssessment(BaseModel):
+    """Structured output for the fit assessment LLM call."""
+
+    verdict: Literal["good_fit", "poor_fit"] = Field(
+        ..., description="Whether the job is a good fit for the candidate"
+    )
+    reasoning: str = Field(..., description="Short explanation for the verdict")
+
+
+def _result(
+    passed: bool, reason: str, config_obj, extracted_value: Any
+) -> Dict[str, Any]:
+    """Build a criterion result dict matching the rule-based evaluator shape."""
+    return {
+        "pass": passed,
+        "reason": reason,
+        "mode": config_obj.mode.value,
+        "extracted_value": extracted_value,
+    }
+
+
+def evaluate_fit(job_posting_text: str, preferences: JobPreferences) -> Dict[str, Any]:
+    """Assess fit between the posting and the user's profile via an LLM call.
+
+    Skipped (treated per ``fit_config.none_policy``) when the user has not
+    provided a target role description.
+
+    Args:
+        job_posting_text: Raw job posting text.
+        preferences: The user's job-search preferences.
+
+    Returns:
+        A criterion result dict with the same shape as the rule-based criteria.
+    """
+    fit_config = preferences.fit_config
+
+    if not preferences.target_role_description.strip():
+        passed = fit_config.none_policy == NonePolicy.PASS
+        decision = "pass" if passed else "fail"
+        reason = (
+            "No target role description provided; fit not assessed and counted "
+            f"as {decision} per preference"
+        )
+        return _result(passed, reason, fit_config, None)
+
+    model = get_chat_model_by_profile_name(config.agents.job_evaluation_fit)
+    structured_llm = model.with_structured_output(FitAssessment)
+
+    prompt_content = FIT_ASSESSMENT_PROMPT.format(
+        target_role_description=truncate_text(
+            preferences.target_role_description,
+            MAX_ROLE_DESCRIPTION_CHARS,
+            "target role description",
+        ),
+        key_skills=", ".join(preferences.key_skills) or "(none provided)",
+        job_text=truncate_text(
+            job_posting_text, MAX_JOB_DESCRIPTION_CHARS, "job posting"
+        ),
+    )
+
+    config_dict = langfuse_manager.get_config()
+    logger.info("Assessing job fit via LLM")
+    assessment: FitAssessment = structured_llm.invoke(
+        [HumanMessage(content=prompt_content)], config=config_dict
+    )
+
+    passed = assessment.verdict == "good_fit"
+    return _result(passed, assessment.reasoning, fit_config, assessment.verdict)

--- a/src/core/job_evaluation/fit_evaluator.py
+++ b/src/core/job_evaluation/fit_evaluator.py
@@ -16,11 +16,7 @@ from src.config import config
 from src.llm import get_chat_model_by_profile_name, langfuse_manager
 from src.models.user import JobPreferences, NonePolicy
 from src.utils.logging import get_logger
-from src.utils.text import (
-    MAX_JOB_DESCRIPTION_CHARS,
-    MAX_ROLE_DESCRIPTION_CHARS,
-    truncate_text,
-)
+from src.utils.text import MAX_ROLE_DESCRIPTION_CHARS, truncate_text
 
 logger = get_logger(__name__)
 
@@ -53,7 +49,7 @@ def evaluate_fit(job_posting_text: str, preferences: JobPreferences) -> Dict[str
     provided a target role description.
 
     Args:
-        job_posting_text: Raw job posting text.
+        job_posting_text: Job posting text, already length-bounded by the caller.
         preferences: The user's job-search preferences.
 
     Returns:
@@ -87,9 +83,7 @@ def evaluate_fit(job_posting_text: str, preferences: JobPreferences) -> Dict[str
                 "target role description",
             ),
             key_skills=", ".join(preferences.key_skills) or "(none provided)",
-            job_text=truncate_text(
-                job_posting_text, MAX_JOB_DESCRIPTION_CHARS, "job posting"
-            ),
+            job_text=job_posting_text,
         )
         config_dict = langfuse_manager.get_config()
         assessment: FitAssessment = structured_llm.invoke(

--- a/src/core/job_evaluation/fit_evaluator.py
+++ b/src/core/job_evaluation/fit_evaluator.py
@@ -25,9 +25,12 @@ class FitAssessment(BaseModel):
     """Structured output for the fit assessment LLM call."""
 
     verdict: Literal["good_fit", "poor_fit"] = Field(
-        ..., description="Whether the job is a good fit for the candidate"
+        ...,
+        description="Whether the role's focus matches the candidate's target role/skills",
     )
-    reasoning: str = Field(..., description="Short explanation for the verdict")
+    reasoning: str = Field(
+        ..., description="Short explanation referring only to subject-matter alignment"
+    )
 
 
 def _result(

--- a/src/core/job_evaluation/fit_evaluator.py
+++ b/src/core/job_evaluation/fit_evaluator.py
@@ -70,31 +70,32 @@ def evaluate_fit(job_posting_text: str, preferences: JobPreferences) -> Dict[str
         )
         return _result(passed, reason, fit_config, None)
 
-    model = get_chat_model_by_profile_name(config.agents.job_evaluation_fit)
-    structured_llm = model.with_structured_output(FitAssessment)
-
-    prompt_content = FIT_ASSESSMENT_PROMPT.format(
-        target_role_description=truncate_text(
-            preferences.target_role_description,
-            MAX_ROLE_DESCRIPTION_CHARS,
-            "target role description",
-        ),
-        key_skills=", ".join(preferences.key_skills) or "(none provided)",
-        job_text=truncate_text(
-            job_posting_text, MAX_JOB_DESCRIPTION_CHARS, "job posting"
-        ),
-    )
-
-    config_dict = langfuse_manager.get_config()
+    # Fit is one of many criteria. Any failure here -- model construction
+    # (including a lazy provider ImportError), prompt formatting, the LLM call
+    # (network, rate limit), or structured-output parsing -- must not discard
+    # the rule-based results. The whole pipeline is wrapped so this function
+    # never raises; on failure it falls back to the none policy. This keeps the
+    # isolation guarantee independent of how the caller wraps the call.
     logger.info("Assessing job fit via LLM")
     try:
+        model = get_chat_model_by_profile_name(config.agents.job_evaluation_fit)
+        structured_llm = model.with_structured_output(FitAssessment)
+        prompt_content = FIT_ASSESSMENT_PROMPT.format(
+            target_role_description=truncate_text(
+                preferences.target_role_description,
+                MAX_ROLE_DESCRIPTION_CHARS,
+                "target role description",
+            ),
+            key_skills=", ".join(preferences.key_skills) or "(none provided)",
+            job_text=truncate_text(
+                job_posting_text, MAX_JOB_DESCRIPTION_CHARS, "job posting"
+            ),
+        )
+        config_dict = langfuse_manager.get_config()
         assessment: FitAssessment = structured_llm.invoke(
             [HumanMessage(content=prompt_content)], config=config_dict
         )
     except Exception as e:
-        # Fit is one of many criteria. A transient LLM failure (network, rate
-        # limit, structured-output parse error) must not discard the
-        # rule-based results, so fall back to the none policy.
         passed = fit_config.none_policy == NonePolicy.PASS
         decision = "pass" if passed else "fail"
         reason = f"Fit assessment failed ({e}); counted as {decision} per preference"

--- a/src/core/job_evaluation/recommender.py
+++ b/src/core/job_evaluation/recommender.py
@@ -1,33 +1,37 @@
 """
-Job recommendation core logic
+Job recommendation core logic.
 
-This module contains the core business logic for generating job application
-recommendations based on evaluation results. It's designed to be framework-agnostic
-and reusable across different contexts.
+Turns per-criterion evaluation results into an APPLY / DO_NOT_APPLY decision,
+respecting each criterion's ``mode`` (required vs. optional). Only required
+criteria can block an APPLY recommendation; optional criteria are reported for
+transparency but do not gate the decision.
 """
 
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, List, Tuple
 
+from src.models.user import CriterionMode
 from src.utils.logging import get_logger
 
 logger = get_logger(__name__)
 
 
+def _is_criterion(result: Any) -> bool:
+    """Return True if ``result`` is a well-formed criterion result dict."""
+    return isinstance(result, dict) and "pass" in result and "mode" in result
+
+
 def generate_recommendation_from_evaluation(
     evaluation_result: Dict[str, Any],
 ) -> Tuple[str, str]:
-    """
-    Generate job application recommendation based on evaluation results.
-
-    This function contains the core business logic for recommendation generation,
-    independent of any specific workflow or state management framework.
+    """Generate an application recommendation from evaluation results.
 
     Args:
-        evaluation_result: Dictionary containing evaluation results for each criteria
+        evaluation_result: Mapping of criterion name to its result dict
+            (``pass``, ``reason``, ``mode``, ``extracted_value``).
 
     Returns:
         Tuple of (recommendation, reasoning) where recommendation is one of
-        "APPLY", "DO_NOT_APPLY", or "ERROR"
+        "APPLY", "DO_NOT_APPLY", or "ERROR".
     """
     if not evaluation_result or "error" in evaluation_result:
         logger.warning("Invalid or empty evaluation result for recommendation")
@@ -35,34 +39,45 @@ def generate_recommendation_from_evaluation(
 
     logger.info("Generating recommendation from evaluation results")
 
-    # Count passed and failed criteria
-    passed_criteria = []
-    failed_criteria = []
+    required_failures: List[str] = []
+    optional_failures: List[str] = []
+    required_passes: List[str] = []
 
     for criterion, result in evaluation_result.items():
-        if isinstance(result, dict) and "pass" in result:
-            if result["pass"]:
-                passed_criteria.append(f"{criterion}: {result['reason']}")
-                logger.debug(f"Criterion passed: {criterion}")
-            else:
-                failed_criteria.append(f"{criterion}: {result['reason']}")
-                logger.debug(f"Criterion failed: {criterion}")
+        if not _is_criterion(result):
+            continue
 
-    # Generate recommendation based on results
-    if not failed_criteria:
-        recommendation = "APPLY"
-        reasoning = f"All criteria passed: {'; '.join(passed_criteria)}"
-        logger.info(
-            f"Recommendation: APPLY - all {len(passed_criteria)} criteria passed"
-        )
-    else:
-        recommendation = "DO_NOT_APPLY"
-        if failed_criteria:
-            reasoning = f"Failed criteria: {'; '.join(failed_criteria)}"
+        reason = result.get("reason", "")
+        entry = f"{criterion}: {reason}"
+        is_required = result["mode"] == CriterionMode.REQUIRED.value
+
+        if result["pass"]:
+            if is_required:
+                required_passes.append(entry)
         else:
-            reasoning = "Job does not meet evaluation criteria"
-        logger.info(
-            f"Recommendation: DO_NOT_APPLY - {len(failed_criteria)} criteria failed"
-        )
+            if is_required:
+                required_failures.append(entry)
+            else:
+                optional_failures.append(entry)
 
+    if required_failures:
+        recommendation = "DO_NOT_APPLY"
+        reasoning = f"Required criteria failed: {'; '.join(required_failures)}"
+        if optional_failures:
+            reasoning += f". Optional concerns: {'; '.join(optional_failures)}"
+        logger.info(
+            "Recommendation: DO_NOT_APPLY - %d required criteria failed",
+            len(required_failures),
+        )
+        return recommendation, reasoning
+
+    recommendation = "APPLY"
+    reasoning = "All required criteria passed"
+    if required_passes:
+        reasoning += f": {'; '.join(required_passes)}"
+    if optional_failures:
+        reasoning += (
+            f". Optional concerns (non-blocking): {'; '.join(optional_failures)}"
+        )
+    logger.info("Recommendation: APPLY - no required criteria failed")
     return recommendation, reasoning

--- a/src/core/job_evaluation/recommender.py
+++ b/src/core/job_evaluation/recommender.py
@@ -20,6 +20,11 @@ def _is_criterion(result: Any) -> bool:
     return isinstance(result, dict) and "pass" in result and "mode" in result
 
 
+def _display_name(criterion_key: str) -> str:
+    """Turn 'employment_type' into 'employment type' for readable lists."""
+    return criterion_key.replace("_", " ")
+
+
 def generate_recommendation_from_evaluation(
     evaluation_result: Dict[str, Any],
 ) -> Tuple[str, str]:
@@ -31,7 +36,9 @@ def generate_recommendation_from_evaluation(
 
     Returns:
         Tuple of (recommendation, reasoning) where recommendation is one of
-        "APPLY", "DO_NOT_APPLY", or "ERROR".
+        "APPLY", "DO_NOT_APPLY", or "ERROR". Reasoning is a brief summary that
+        names which criteria failed; the per-criterion ``reason`` text is left
+        to the criteria breakdown so the two views don't duplicate each other.
     """
     if not evaluation_result or "error" in evaluation_result:
         logger.warning("Invalid or empty evaluation result for recommendation")
@@ -41,43 +48,30 @@ def generate_recommendation_from_evaluation(
 
     required_failures: List[str] = []
     optional_failures: List[str] = []
-    required_passes: List[str] = []
 
     for criterion, result in evaluation_result.items():
-        if not _is_criterion(result):
+        if not _is_criterion(result) or result["pass"]:
             continue
-
-        reason = result.get("reason", "")
-        entry = f"{criterion}: {reason}"
-        is_required = result["mode"] == CriterionMode.REQUIRED.value
-
-        if result["pass"]:
-            if is_required:
-                required_passes.append(entry)
+        if result["mode"] == CriterionMode.REQUIRED.value:
+            required_failures.append(criterion)
         else:
-            if is_required:
-                required_failures.append(entry)
-            else:
-                optional_failures.append(entry)
+            optional_failures.append(criterion)
 
     if required_failures:
-        recommendation = "DO_NOT_APPLY"
-        reasoning = f"Required criteria failed: {'; '.join(required_failures)}"
+        names = ", ".join(_display_name(c) for c in required_failures)
+        reasoning = f"Required criteria failed: {names}."
         if optional_failures:
-            reasoning += f". Optional concerns: {'; '.join(optional_failures)}"
+            opt = ", ".join(_display_name(c) for c in optional_failures)
+            reasoning += f" Optional concerns: {opt}."
         logger.info(
             "Recommendation: DO_NOT_APPLY - %d required criteria failed",
             len(required_failures),
         )
-        return recommendation, reasoning
+        return "DO_NOT_APPLY", reasoning
 
-    recommendation = "APPLY"
-    reasoning = "All required criteria passed"
-    if required_passes:
-        reasoning += f": {'; '.join(required_passes)}"
+    reasoning = "All required criteria passed."
     if optional_failures:
-        reasoning += (
-            f". Optional concerns (non-blocking): {'; '.join(optional_failures)}"
-        )
+        opt = ", ".join(_display_name(c) for c in optional_failures)
+        reasoning += f" Optional concerns (non-blocking): {opt}."
     logger.info("Recommendation: APPLY - no required criteria failed")
-    return recommendation, reasoning
+    return "APPLY", reasoning

--- a/src/core/preferences.py
+++ b/src/core/preferences.py
@@ -1,0 +1,77 @@
+"""User preference persistence.
+
+Loads and saves :class:`JobPreferences` to a local YAML file so the user's job
+evaluation preferences persist across sessions.
+"""
+
+from pathlib import Path
+from typing import Union
+
+import yaml
+from pydantic import ValidationError
+
+from src.models.user import JobPreferences
+from src.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+# Default location for the persisted preferences, relative to the project root.
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+DEFAULT_PREFERENCES_PATH = _PROJECT_ROOT / "data" / "user_preferences.yaml"
+
+
+def load_preferences(
+    path: Union[str, Path] = DEFAULT_PREFERENCES_PATH,
+) -> JobPreferences:
+    """Load preferences from a YAML file.
+
+    Returns default preferences if the file is missing, malformed, or fails
+    validation (for example, after a schema change), rather than raising.
+
+    Args:
+        path: Path to the YAML preferences file.
+
+    Returns:
+        A validated :class:`JobPreferences` instance.
+    """
+    path = Path(path)
+
+    if not path.exists():
+        logger.info("No preferences file at %s; using defaults", path)
+        return JobPreferences()
+
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+        if not data:
+            logger.warning("Preferences file %s is empty; using defaults", path)
+            return JobPreferences()
+        return JobPreferences.model_validate(data)
+    except (yaml.YAMLError, ValidationError, OSError) as e:
+        logger.warning(
+            "Failed to load preferences from %s (%s); using defaults", path, e
+        )
+        return JobPreferences()
+
+
+def save_preferences(
+    preferences: JobPreferences,
+    path: Union[str, Path] = DEFAULT_PREFERENCES_PATH,
+) -> None:
+    """Persist preferences to a YAML file.
+
+    Uses ``model_dump(mode="json")`` so ``StrEnum`` values are written as plain
+    strings rather than Python enum objects.
+
+    Args:
+        preferences: The preferences to save.
+        path: Destination path for the YAML file.
+    """
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    data = preferences.model_dump(mode="json")
+    with open(path, "w", encoding="utf-8") as f:
+        yaml.safe_dump(data, f, sort_keys=False, default_flow_style=False)
+
+    logger.info("Saved preferences to %s", path)

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -9,7 +9,12 @@ from src.models.enums import Environment, JobSource, JobStatus
 from src.models.evaluation import EvaluationResult
 from src.models.job import JobDescription, JobPostingExtractionSchema
 from src.models.resume import Education, Experience, Resume
-from src.models.user import UserPreferences
+from src.models.user import (
+    CriterionConfig,
+    CriterionMode,
+    JobPreferences,
+    NonePolicy,
+)
 
 __all__ = [
     # Base
@@ -25,5 +30,9 @@ __all__ = [
     "Education",
     "Experience",
     "Resume",
-    "UserPreferences",
+    # User preferences
+    "JobPreferences",
+    "CriterionConfig",
+    "CriterionMode",
+    "NonePolicy",
 ]

--- a/src/models/job.py
+++ b/src/models/job.py
@@ -15,7 +15,9 @@ class JobDescription(BaseDataModel):
     title: Optional[str] = Field(None, description="Job title.")
     company: Optional[str] = Field(None, description="Company name.")
     description: Optional[str] = Field(None, description="Full job description text.")
-    is_remote: Optional[bool] = Field(False, description="Is the job remote?")
+    is_remote: Optional[bool] = Field(
+        None, description="Is the job remote? None = unknown."
+    )
     requirements: List[str] = Field(
         default_factory=list, description="Job requirements."
     )

--- a/src/models/job.py
+++ b/src/models/job.py
@@ -2,7 +2,7 @@
 
 from typing import Any, Dict, List, Literal, Optional
 
-from pydantic import ConfigDict, Field, field_validator
+from pydantic import ConfigDict, Field, field_validator, model_validator
 
 from src.models.base import BaseDataModel
 from src.models.enums import JobSource, JobStatus
@@ -153,19 +153,20 @@ class JobPostingExtractionSchema(BaseDataModel):
         examples=[["health", "dental", "401k", "pto"], []],
     )
 
-    @field_validator("salary_max")
-    @classmethod
-    def salary_max_must_be_greater_than_min(
-        cls, v: Optional[int], info
-    ) -> Optional[int]:
-        """Validate that salary_max is greater than salary_min if both are provided."""
-        if v is not None and info.data.get("salary_min") is not None:
-            salary_min = info.data["salary_min"]
-            if v < salary_min:
-                raise ValueError(
-                    "salary_max must be greater than or equal to salary_min"
-                )
-        return v
+    @model_validator(mode="after")
+    def salary_max_must_be_greater_than_min(self) -> "JobPostingExtractionSchema":
+        """Validate that salary_max >= salary_min when both are provided.
+
+        Uses an after-model validator so the check reads the fully-populated
+        fields and does not depend on field declaration order.
+        """
+        if (
+            self.salary_max is not None
+            and self.salary_min is not None
+            and self.salary_max < self.salary_min
+        ):
+            raise ValueError("salary_max must be greater than or equal to salary_min")
+        return self
 
     model_config = ConfigDict(
         # Enable JSON schema generation with examples

--- a/src/models/job.py
+++ b/src/models/job.py
@@ -100,6 +100,59 @@ class JobPostingExtractionSchema(BaseDataModel):
         examples=["ic", "manager", "unclear"],
     )
 
+    seniority_level: Literal[
+        "junior", "mid", "senior", "staff", "principal", "lead", "unclear"
+    ] = Field(
+        default="unclear",
+        description="Seniority level inferred from the job title and description",
+        examples=["senior", "staff", "principal", "unclear"],
+    )
+
+    visa_sponsorship: Literal["yes", "no", "unclear"] = Field(
+        default="unclear",
+        description="Whether the posting mentions offering visa sponsorship",
+        examples=["yes", "no", "unclear"],
+    )
+
+    employment_type: Literal[
+        "full-time", "part-time", "contract", "internship", "unclear"
+    ] = Field(
+        default="unclear",
+        description="Employment type of the role",
+        examples=["full-time", "contract", "unclear"],
+    )
+
+    travel_required: Literal["yes", "no", "unclear"] = Field(
+        default="unclear",
+        description="Whether the role requires travel",
+        examples=["yes", "no", "unclear"],
+    )
+
+    education_requirement: Literal[
+        "associate", "bachelor", "master", "phd", "none", "unclear"
+    ] = Field(
+        default="unclear",
+        description=(
+            "Minimum education the posting requires. Use 'none' when the posting "
+            "explicitly states no degree is required, 'unclear' when not mentioned."
+        ),
+        examples=["bachelor", "master", "none", "unclear"],
+    )
+
+    equity_offered: List[Literal["stock_options", "rsus"]] = Field(
+        default_factory=list,
+        description="Equity types the posting mentions offering (empty if not mentioned)",
+        examples=[["rsus"], ["stock_options"], []],
+    )
+
+    benefits_offered: List[
+        Literal["health", "vision", "dental", "life", "std", "ltd", "401k", "pto"]
+    ] = Field(
+        default_factory=list,
+        description="Benefits the posting mentions offering (empty if not mentioned)",
+        examples=[["health", "dental", "401k", "pto"], []],
+    )
+
     @field_validator("salary_max")
     @classmethod
     def salary_max_must_be_greater_than_min(

--- a/src/models/user.py
+++ b/src/models/user.py
@@ -24,7 +24,9 @@ class CriterionConfig(BaseModel):
     """Per-criterion configuration: required/optional and how to handle missing data."""
 
     mode: CriterionMode = CriterionMode.REQUIRED
-    none_policy: NonePolicy = NonePolicy.FAIL
+    # Matches the JobPreferences product-wide default so hand-edited YAML with
+    # only `mode` set picks up the same none_policy as the full factories.
+    none_policy: NonePolicy = NonePolicy.PASS
 
 
 def _config(mode: CriterionMode, none_policy: NonePolicy) -> CriterionConfig:

--- a/src/models/user.py
+++ b/src/models/user.py
@@ -1,17 +1,136 @@
 """User-related models for the job search assistant."""
 
-from typing import List
+from enum import StrEnum
+from typing import List, Literal
 
-from pydantic import Field
-
-from src.models.base import BaseDataModel
+from pydantic import BaseModel, Field
 
 
-class UserPreferences(BaseDataModel):
-    """Model representing user job search preferences."""
+class CriterionMode(StrEnum):
+    """Whether a criterion must pass for an APPLY recommendation."""
 
-    job_titles: List[str] = Field(..., description="List of desired job titles.")
-    # TODO: Add more preferences like salary, location, company size, etc.
-    # TODO: Add weights to preferences
-    # TODO: Add must-have vs. nice-to-have preferences
-    # TODO: Add ability to specify how to evaluate each preference
+    REQUIRED = "required"  # Must pass for APPLY
+    OPTIONAL = "optional"  # Evaluated and reported, but does not block APPLY
+
+
+class NonePolicy(StrEnum):
+    """How to treat a criterion when the job posting lacks the data to judge it."""
+
+    PASS = "pass"  # Treat missing data as passing
+    FAIL = "fail"  # Treat missing data as failing
+
+
+class CriterionConfig(BaseModel):
+    """Per-criterion configuration: required/optional and how to handle missing data."""
+
+    mode: CriterionMode = CriterionMode.REQUIRED
+    none_policy: NonePolicy = NonePolicy.FAIL
+
+
+def _config(mode: CriterionMode, none_policy: NonePolicy) -> CriterionConfig:
+    """Helper to build a default CriterionConfig for use in default_factory."""
+    return CriterionConfig(mode=mode, none_policy=none_policy)
+
+
+class JobPreferences(BaseModel):
+    """User job-search preferences used to evaluate postings.
+
+    Each evaluable attribute pairs a value (what the user wants) with a
+    ``CriterionConfig`` (whether it is required and how to treat missing data).
+    """
+
+    # --- Criterion values ---
+    min_salary: int = Field(
+        default=100_000, ge=0, description="Minimum acceptable annual salary (USD)"
+    )
+    acceptable_locations: List[Literal["onsite", "remote", "hybrid"]] = Field(
+        default_factory=lambda: ["remote"],
+        description="Acceptable work-location policies",
+    )
+    acceptable_levels: List[Literal["ic", "manager"]] = Field(
+        default_factory=lambda: ["ic", "manager"],
+        description="Acceptable role types",
+    )
+    acceptable_seniority: List[
+        Literal["junior", "mid", "senior", "staff", "principal", "lead"]
+    ] = Field(
+        default_factory=lambda: ["senior", "staff", "principal", "lead"],
+        description="Acceptable seniority levels",
+    )
+    visa_sponsorship_required: bool = Field(
+        default=False, description="Whether the user requires visa sponsorship"
+    )
+    company_blacklist: List[str] = Field(
+        default_factory=list, description="Companies the user will not apply to"
+    )
+    acceptable_employment_types: List[
+        Literal["full-time", "part-time", "contract", "internship"]
+    ] = Field(
+        default_factory=lambda: ["full-time"],
+        description="Acceptable employment types",
+    )
+    willing_to_travel: bool = Field(
+        default=False, description="Whether the user is willing to travel"
+    )
+    education_level: Literal["associate", "bachelor", "master", "phd"] = Field(
+        default="bachelor", description="The user's own highest education level"
+    )
+    acceptable_equity_types: List[Literal["stock_options", "rsus"]] = Field(
+        default_factory=list,
+        description="Equity types the user wants (empty = no equity preference)",
+    )
+    required_benefits: List[
+        Literal["health", "vision", "dental", "life", "std", "ltd", "401k", "pto"]
+    ] = Field(
+        default_factory=list,
+        description="Benefits the user requires (empty = no benefit preference)",
+    )
+
+    # --- Fit profile (used by the LLM fit evaluation) ---
+    target_role_description: str = Field(
+        default="",
+        description="Free-text description of the user's target role and focus",
+    )
+    key_skills: List[str] = Field(
+        default_factory=list, description="The user's key skills"
+    )
+
+    # --- Per-criterion configuration ---
+    salary_config: CriterionConfig = Field(
+        default_factory=lambda: _config(CriterionMode.REQUIRED, NonePolicy.FAIL)
+    )
+    location_config: CriterionConfig = Field(
+        default_factory=lambda: _config(CriterionMode.REQUIRED, NonePolicy.FAIL)
+    )
+    level_config: CriterionConfig = Field(
+        default_factory=lambda: _config(CriterionMode.OPTIONAL, NonePolicy.PASS)
+    )
+    seniority_config: CriterionConfig = Field(
+        default_factory=lambda: _config(CriterionMode.REQUIRED, NonePolicy.FAIL)
+    )
+    visa_config: CriterionConfig = Field(
+        default_factory=lambda: _config(CriterionMode.OPTIONAL, NonePolicy.PASS)
+    )
+    blacklist_config: CriterionConfig = Field(
+        default_factory=lambda: _config(CriterionMode.REQUIRED, NonePolicy.PASS)
+    )
+    employment_type_config: CriterionConfig = Field(
+        default_factory=lambda: _config(CriterionMode.OPTIONAL, NonePolicy.PASS)
+    )
+    travel_config: CriterionConfig = Field(
+        default_factory=lambda: _config(CriterionMode.OPTIONAL, NonePolicy.PASS)
+    )
+    education_config: CriterionConfig = Field(
+        default_factory=lambda: _config(CriterionMode.OPTIONAL, NonePolicy.PASS)
+    )
+    equity_config: CriterionConfig = Field(
+        default_factory=lambda: _config(CriterionMode.OPTIONAL, NonePolicy.PASS)
+    )
+    benefits_config: CriterionConfig = Field(
+        default_factory=lambda: _config(CriterionMode.OPTIONAL, NonePolicy.PASS)
+    )
+    fit_config: CriterionConfig = Field(
+        # Optional + pass by default so a fresh user with no target role
+        # description does not get DO_NOT_APPLY for every job.
+        default_factory=lambda: _config(CriterionMode.OPTIONAL, NonePolicy.PASS)
+    )

--- a/src/models/user.py
+++ b/src/models/user.py
@@ -96,17 +96,20 @@ class JobPreferences(BaseModel):
     )
 
     # --- Per-criterion configuration ---
+    # Note: every criterion defaults to none_policy=PASS so that a posting only
+    # fails a criterion when it explicitly contains disqualifying info, never
+    # just for omitting it (casting a wide net).
     salary_config: CriterionConfig = Field(
-        default_factory=lambda: _config(CriterionMode.REQUIRED, NonePolicy.FAIL)
+        default_factory=lambda: _config(CriterionMode.REQUIRED, NonePolicy.PASS)
     )
     location_config: CriterionConfig = Field(
-        default_factory=lambda: _config(CriterionMode.REQUIRED, NonePolicy.FAIL)
+        default_factory=lambda: _config(CriterionMode.REQUIRED, NonePolicy.PASS)
     )
     level_config: CriterionConfig = Field(
         default_factory=lambda: _config(CriterionMode.OPTIONAL, NonePolicy.PASS)
     )
     seniority_config: CriterionConfig = Field(
-        default_factory=lambda: _config(CriterionMode.REQUIRED, NonePolicy.FAIL)
+        default_factory=lambda: _config(CriterionMode.OPTIONAL, NonePolicy.PASS)
     )
     visa_config: CriterionConfig = Field(
         default_factory=lambda: _config(CriterionMode.OPTIONAL, NonePolicy.PASS)
@@ -115,7 +118,7 @@ class JobPreferences(BaseModel):
         default_factory=lambda: _config(CriterionMode.REQUIRED, NonePolicy.PASS)
     )
     employment_type_config: CriterionConfig = Field(
-        default_factory=lambda: _config(CriterionMode.OPTIONAL, NonePolicy.PASS)
+        default_factory=lambda: _config(CriterionMode.REQUIRED, NonePolicy.PASS)
     )
     travel_config: CriterionConfig = Field(
         default_factory=lambda: _config(CriterionMode.OPTIONAL, NonePolicy.PASS)

--- a/src/utils/text.py
+++ b/src/utils/text.py
@@ -1,0 +1,44 @@
+"""Text utilities for the Job Search Assistant.
+
+Provides helpers for bounding user-supplied text before it reaches LLM calls,
+preventing runaway cost and context window overflows.
+"""
+
+from src.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+# Character limits for user-supplied inputs sent to LLMs. These are generous
+# (~5x the average input) so legitimate text is never truncated, while still
+# catching accidental pastes of entire documents or web pages.
+MAX_JOB_DESCRIPTION_CHARS = 20_000
+MAX_ROLE_DESCRIPTION_CHARS = 2_000
+
+_TRUNCATION_MARKER = "\n[truncated]"
+
+
+def truncate_text(text: str, max_chars: int, label: str = "input") -> str:
+    """Truncate ``text`` to ``max_chars`` characters.
+
+    If truncation occurs, a ``[truncated]`` marker is appended so the LLM knows
+    the input is incomplete, and a warning is logged.
+
+    Args:
+        text: The text to bound.
+        max_chars: Maximum number of characters to keep (before the marker).
+        label: Human-readable name of the field, used in the warning log.
+
+    Returns:
+        The original text if within the limit, otherwise the truncated text
+        with a marker appended.
+    """
+    if text is None:
+        return text
+
+    if len(text) <= max_chars:
+        return text
+
+    logger.warning(
+        "Truncating %s from %d to %d characters", label, len(text), max_chars
+    )
+    return text[:max_chars] + _TRUNCATION_MARKER

--- a/tests/integration/agent/test_workflow_integration.py
+++ b/tests/integration/agent/test_workflow_integration.py
@@ -19,15 +19,25 @@ from src.exceptions.llm import LLMProviderError
 class TestJobEvaluationWorkflow:
     """Integration tests for the job evaluation workflow."""
 
+    @patch("src.agent.workflows.job_evaluation.main.load_preferences")
+    @patch("src.agent.workflows.job_evaluation.main.evaluate_fit")
     @patch("src.agent.tools.extraction.schema_extraction_tool._extract_with_schema")
     @patch(
         "src.agent.tools.extraction.schema_extraction_tool.validate_extraction_result"
     )
-    @patch("src.core.job_evaluation.evaluator.evaluate_job_against_criteria")
+    @patch("src.agent.workflows.job_evaluation.main.evaluate_job_against_criteria")
     def test_workflow_should_apply(
-        self, mock_evaluate, mock_validate, mock_extract_schema
+        self,
+        mock_evaluate,
+        mock_validate,
+        mock_extract_schema,
+        mock_fit,
+        mock_load_prefs,
     ):
         """Test complete workflow resulting in APPLY recommendation."""
+        from src.models.user import JobPreferences
+
+        mock_load_prefs.return_value = JobPreferences()
         # Setup extraction with passing criteria
         mock_extract_schema.return_value = {
             "title": "Staff Software Engineer",
@@ -39,12 +49,18 @@ class TestJobEvaluationWorkflow:
         }
         mock_validate.return_value = True
         mock_evaluate.return_value = {
-            "salary": {"pass": True, "reason": "Salary meets requirement"},
-            "remote": {"pass": True, "reason": "Position is remote"},
-            "title_level": {
+            "salary": {
                 "pass": True,
-                "reason": "IC role has appropriate seniority",
+                "reason": "Salary meets requirement",
+                "mode": "required",
+                "extracted_value": 170000,
             },
+        }
+        mock_fit.return_value = {
+            "pass": True,
+            "reason": "Good fit",
+            "mode": "optional",
+            "extracted_value": "good_fit",
         }
 
         final_state = run_job_evaluation_workflow(
@@ -58,16 +74,25 @@ class TestJobEvaluationWorkflow:
         assert final_state.extracted_info["title"] == "Staff Software Engineer"
         assert final_state.extracted_info["company"] == "TechCorp"
 
+    @patch("src.agent.workflows.job_evaluation.main.load_preferences")
+    @patch("src.agent.workflows.job_evaluation.main.evaluate_fit")
     @patch("src.agent.tools.extraction.schema_extraction_tool._extract_with_schema")
     @patch(
         "src.agent.tools.extraction.schema_extraction_tool.validate_extraction_result"
     )
-    @patch("src.core.job_evaluation.evaluator.evaluate_job_against_criteria")
+    @patch("src.agent.workflows.job_evaluation.main.evaluate_job_against_criteria")
     def test_workflow_should_not_apply(
-        self, mock_evaluate, mock_validate, mock_extract_schema
+        self,
+        mock_evaluate,
+        mock_validate,
+        mock_extract_schema,
+        mock_fit,
+        mock_load_prefs,
     ):
         """Test complete workflow resulting in DO_NOT_APPLY recommendation."""
-        # Setup extraction with failing criteria
+        from src.models.user import JobPreferences
+
+        mock_load_prefs.return_value = JobPreferences()
         mock_extract_schema.return_value = {
             "title": "Junior Software Engineer",
             "company": "TechCorp",
@@ -78,12 +103,18 @@ class TestJobEvaluationWorkflow:
         }
         mock_validate.return_value = True
         mock_evaluate.return_value = {
-            "salary": {"pass": False, "reason": "Salary too low"},
-            "remote": {"pass": False, "reason": "Position is not remote"},
-            "title_level": {
+            "salary": {
                 "pass": False,
-                "reason": "IC role lacks required seniority",
+                "reason": "Salary too low",
+                "mode": "required",
+                "extracted_value": 90000,
             },
+        }
+        mock_fit.return_value = {
+            "pass": True,
+            "reason": "n/a",
+            "mode": "optional",
+            "extracted_value": None,
         }
 
         final_state = run_job_evaluation_workflow(
@@ -95,15 +126,25 @@ class TestJobEvaluationWorkflow:
         assert final_state.extracted_info is not None
         assert final_state.evaluation_result is not None
 
+    @patch("src.agent.workflows.job_evaluation.main.load_preferences")
+    @patch("src.agent.workflows.job_evaluation.main.evaluate_fit")
     @patch("src.agent.tools.extraction.schema_extraction_tool._extract_with_schema")
     @patch(
         "src.agent.tools.extraction.schema_extraction_tool.validate_extraction_result"
     )
-    @patch("src.core.job_evaluation.evaluator.evaluate_job_against_criteria")
+    @patch("src.agent.workflows.job_evaluation.main.evaluate_job_against_criteria")
     def test_workflow_mixed_results(
-        self, mock_evaluate, mock_validate, mock_extract_schema
+        self,
+        mock_evaluate,
+        mock_validate,
+        mock_extract_schema,
+        mock_fit,
+        mock_load_prefs,
     ):
-        """Test workflow with mixed evaluation results."""
+        """Test workflow where a required criterion fails despite optional passes."""
+        from src.models.user import JobPreferences
+
+        mock_load_prefs.return_value = JobPreferences()
         mock_extract_schema.return_value = {
             "title": "Senior Software Engineer",
             "company": "TechCorp",
@@ -114,12 +155,24 @@ class TestJobEvaluationWorkflow:
         }
         mock_validate.return_value = True
         mock_evaluate.return_value = {
-            "salary": {"pass": True, "reason": "Salary meets requirement"},
-            "remote": {"pass": True, "reason": "Position is remote"},
-            "title_level": {
-                "pass": False,
-                "reason": "IC role lacks required seniority",
+            "salary": {
+                "pass": True,
+                "reason": "Salary meets requirement",
+                "mode": "required",
+                "extracted_value": 140000,
             },
+            "seniority": {
+                "pass": False,
+                "reason": "Seniority not acceptable",
+                "mode": "required",
+                "extracted_value": "mid",
+            },
+        }
+        mock_fit.return_value = {
+            "pass": True,
+            "reason": "n/a",
+            "mode": "optional",
+            "extracted_value": None,
         }
 
         final_state = run_job_evaluation_workflow(

--- a/tests/unit/agent/test_job_evaluation_nodes.py
+++ b/tests/unit/agent/test_job_evaluation_nodes.py
@@ -1,0 +1,48 @@
+"""
+Unit tests for individual job evaluation workflow nodes.
+"""
+
+from src.agent.workflows.job_evaluation.main import extract_job_info, validate_input
+from src.agent.workflows.job_evaluation.states import JobEvaluationState
+from src.utils.text import MAX_JOB_DESCRIPTION_CHARS
+
+
+class TestValidateInput:
+    def test_empty_text_returns_error(self):
+        out = validate_input(JobEvaluationState(job_posting_text="   "))
+        assert out["recommendation"] == "ERROR"
+
+    def test_bounds_text_once_and_stores_on_state(self):
+        long_text = "x" * (MAX_JOB_DESCRIPTION_CHARS + 500)
+        out = validate_input(JobEvaluationState(job_posting_text=long_text))
+
+        bounded = out["job_posting_text"]
+        assert bounded.endswith("[truncated]")
+        assert len(bounded) <= MAX_JOB_DESCRIPTION_CHARS + len("\n[truncated]")
+
+    def test_short_text_is_left_unchanged(self):
+        out = validate_input(JobEvaluationState(job_posting_text="Short JD"))
+        assert out["job_posting_text"] == "Short JD"
+
+
+class TestExtractUsesBoundedText:
+    def test_extract_does_not_re_truncate(self, monkeypatch):
+        """extract_job_info should pass state text straight through (already bounded)."""
+        captured = {}
+
+        def fake_extract(text):
+            captured["text"] = text
+            return {"title": "Engineer", "company": "Acme", "salary_max": 200000}
+
+        monkeypatch.setattr(
+            "src.agent.workflows.job_evaluation.main.extract_job_posting",
+            fake_extract,
+        )
+        monkeypatch.setattr(
+            "src.agent.workflows.job_evaluation.main.validate_extraction_result",
+            lambda result, schema: True,
+        )
+
+        state = JobEvaluationState(job_posting_text="already bounded text")
+        extract_job_info(state)
+        assert captured["text"] == "already bounded text"

--- a/tests/unit/config/test_system.py
+++ b/tests/unit/config/test_system.py
@@ -446,8 +446,6 @@ enabled = true
             # Test attribute access
             assert test_config.general.name == "proxy-test"
             assert test_config.logging.level == "DEBUG"
-            assert test_config.evaluation_criteria.min_salary == 150000
-            assert test_config.evaluation_criteria.remote_required is False
 
     def test_proxy_reload(self, tmp_path):
         """Test that proxy reload works correctly."""
@@ -585,7 +583,6 @@ temperature = 0.0
             assert settings.general.name == "integration-test"
             assert settings.general.debug is True  # Overridden by dev.toml
             assert settings.logging.level == "DEBUG"  # Overridden by dev.toml
-            assert settings.evaluation_criteria.min_salary == 150000
             assert (
                 settings.llm_profiles["claude_profile"].temperature == 0.0
             )  # Overridden

--- a/tests/unit/core/job_evaluation/test_evaluator.py
+++ b/tests/unit/core/job_evaluation/test_evaluator.py
@@ -1,138 +1,192 @@
 """
-Unit tests for core job evaluation logic
+Unit tests for core job evaluation logic.
 """
 
-import pytest
-
 from src.core.job_evaluation import evaluate_job_against_criteria
+from src.models.user import CriterionConfig, JobPreferences
 
 
-class TestEvaluateJobAgainstCriteria:
-    """Test the core job evaluation function"""
+def _full_match_info():
+    """Extracted info that passes the default preferences across the board."""
+    return {
+        "title": "Staff Software Engineer",
+        "company": "TechCorp",
+        "salary_min": 150000,
+        "salary_max": 180000,
+        "location_policy": "remote",
+        "role_type": "ic",
+        "seniority_level": "staff",
+        "visa_sponsorship": "yes",
+        "employment_type": "full-time",
+        "travel_required": "no",
+        "education_requirement": "bachelor",
+        "equity_offered": ["rsus"],
+        "benefits_offered": ["health", "dental", "401k", "pto"],
+    }
 
-    def test_all_criteria_pass(self):
-        """Test job that meets all criteria"""
-        job_info = {
-            "salary_max": 180000,
-            "location_policy": "Remote",
-            "role_type": "IC",
-            "title": "Staff Software Engineer",
-        }
 
-        result = evaluate_job_against_criteria(job_info)
-
+class TestSalaryCriterion:
+    def test_salary_passes_when_max_meets_floor(self):
+        prefs = JobPreferences(min_salary=100000)
+        result = evaluate_job_against_criteria(_full_match_info(), prefs)
         assert result["salary"]["pass"] is True
-        assert result["remote"]["pass"] is True
-        assert result["title_level"]["pass"] is True
 
-    def test_low_salary_fails(self):
-        """Test job with salary below minimum"""
-        job_info = {
-            "salary_max": 80000,  # Below 100k minimum
-            "location_policy": "Remote",
-            "role_type": "IC",
-            "title": "Staff Software Engineer",
-        }
+    def test_high_range_passes_low_floor(self):
+        """A $200k-$250k posting passes a $100k floor (regression guard)."""
+        prefs = JobPreferences(min_salary=100000)
+        info = _full_match_info()
+        info.update(salary_min=200000, salary_max=250000)
+        result = evaluate_job_against_criteria(info, prefs)
+        assert result["salary"]["pass"] is True
 
-        result = evaluate_job_against_criteria(job_info)
-
+    def test_salary_below_floor_fails(self):
+        prefs = JobPreferences(min_salary=160000)
+        info = _full_match_info()
+        info["salary_max"] = 120000
+        result = evaluate_job_against_criteria(info, prefs)
         assert result["salary"]["pass"] is False
-        assert "lower than required" in result["salary"]["reason"]
 
-    def test_missing_salary_fails(self):
-        """Test job with no salary information"""
-        job_info = {
-            "location_policy": "Remote",
-            "role_type": "IC",
-            "title": "Staff Software Engineer",
-        }
-
-        result = evaluate_job_against_criteria(job_info)
-
+    def test_missing_salary_respects_none_policy(self):
+        info = _full_match_info()
+        info["salary_max"] = None
+        # Default salary none_policy is FAIL.
+        result = evaluate_job_against_criteria(info, JobPreferences())
         assert result["salary"]["pass"] is False
-        assert result["salary"]["reason"] == "Salary not specified"
 
-    def test_not_remote_fails(self):
-        """Test job that is not remote"""
-        job_info = {
-            "salary_max": 180000,
-            "location_policy": "On-site",
-            "role_type": "IC",
-            "title": "Staff Software Engineer",
-        }
 
-        result = evaluate_job_against_criteria(job_info)
+class TestMembershipCriteria:
+    def test_location_not_acceptable_fails(self):
+        prefs = JobPreferences(acceptable_locations=["remote"])
+        info = _full_match_info()
+        info["location_policy"] = "onsite"
+        result = evaluate_job_against_criteria(info, prefs)
+        assert result["location"]["pass"] is False
 
-        assert result["remote"]["pass"] is False
-        assert "not remote" in result["remote"]["reason"]
+    def test_seniority_not_acceptable_fails(self):
+        prefs = JobPreferences(acceptable_seniority=["staff", "principal"])
+        info = _full_match_info()
+        info["seniority_level"] = "junior"
+        result = evaluate_job_against_criteria(info, prefs)
+        assert result["seniority"]["pass"] is False
 
-    def test_junior_ic_role_fails(self):
-        """Test IC role without required seniority"""
-        job_info = {
-            "salary_max": 180000,
-            "location_policy": "Remote",
-            "role_type": "IC",
-            "title": "Software Engineer",  # No senior/staff/lead/principal
-        }
+    def test_unclear_membership_respects_none_policy(self):
+        info = _full_match_info()
+        info["location_policy"] = "unclear"
+        # Default location none_policy is FAIL.
+        result = evaluate_job_against_criteria(info, JobPreferences())
+        assert result["location"]["pass"] is False
 
-        result = evaluate_job_against_criteria(job_info)
 
-        assert result["title_level"]["pass"] is False
-        assert "lacks required seniority" in result["title_level"]["reason"]
+class TestVisaCriterion:
+    def test_not_required_always_passes(self):
+        prefs = JobPreferences(visa_sponsorship_required=False)
+        info = _full_match_info()
+        info["visa_sponsorship"] = "no"
+        result = evaluate_job_against_criteria(info, prefs)
+        assert result["visa"]["pass"] is True
 
-    def test_non_ic_role_passes_title_check(self):
-        """Test that non-IC roles pass title level requirement"""
-        job_info = {
-            "salary_max": 180000,
-            "location_policy": "Remote",
-            "role_type": "Manager",
-            "title": "Engineering Manager",
-        }
+    def test_required_and_not_offered_fails(self):
+        prefs = JobPreferences(visa_sponsorship_required=True)
+        info = _full_match_info()
+        info["visa_sponsorship"] = "no"
+        result = evaluate_job_against_criteria(info, prefs)
+        assert result["visa"]["pass"] is False
 
-        result = evaluate_job_against_criteria(job_info)
 
-        assert result["title_level"]["pass"] is True
-        assert "not applicable" in result["title_level"]["reason"]
+class TestBlacklistCriterion:
+    def test_empty_blacklist_passes(self):
+        prefs = JobPreferences(company_blacklist=[])
+        result = evaluate_job_against_criteria(_full_match_info(), prefs)
+        assert result["blacklist"]["pass"] is True
 
-    def test_empty_job_info_returns_error(self):
-        """Test behavior with empty job information"""
-        result = evaluate_job_against_criteria({})
+    def test_word_boundary_match_fails(self):
+        prefs = JobPreferences(company_blacklist=["Microsoft"])
+        info = _full_match_info()
+        info["company"] = "Microsoft Co. Ltd."
+        result = evaluate_job_against_criteria(info, prefs)
+        assert result["blacklist"]["pass"] is False
 
-        assert "error" in result
-        assert result["error"] == "No extracted information available"
+    def test_partial_word_does_not_match(self):
+        prefs = JobPreferences(company_blacklist=["Meta"])
+        info = _full_match_info()
+        info["company"] = "Metadata Inc."
+        result = evaluate_job_against_criteria(info, prefs)
+        assert result["blacklist"]["pass"] is True
 
-    def test_none_job_info_returns_error(self):
-        """Test behavior with None job information"""
-        result = evaluate_job_against_criteria(None)
 
-        assert "error" in result
-        assert result["error"] == "No extracted information available"
+class TestTravelCriterion:
+    def test_willing_always_passes(self):
+        prefs = JobPreferences(willing_to_travel=True)
+        info = _full_match_info()
+        info["travel_required"] = "yes"
+        result = evaluate_job_against_criteria(info, prefs)
+        assert result["travel"]["pass"] is True
 
-    def test_various_seniority_levels_pass(self):
-        """Test that various accepted seniority levels pass for IC roles"""
-        seniority_levels = ["lead", "staff", "principal", "senior staff"]
+    def test_not_willing_and_required_fails(self):
+        prefs = JobPreferences(willing_to_travel=False)
+        info = _full_match_info()
+        info["travel_required"] = "yes"
+        result = evaluate_job_against_criteria(info, prefs)
+        assert result["travel"]["pass"] is False
 
-        for level in seniority_levels:
-            job_info = {
-                "salary_max": 180000,
-                "location_policy": "Remote",
-                "role_type": "IC",
-                "title": f"{level} software engineer",
-            }
 
-            result = evaluate_job_against_criteria(job_info)
-            assert result["title_level"]["pass"] is True, f"Failed for {level} title"
+class TestEducationCriterion:
+    def test_user_meets_requirement(self):
+        prefs = JobPreferences(education_level="master")
+        info = _full_match_info()
+        info["education_requirement"] = "bachelor"
+        result = evaluate_job_against_criteria(info, prefs)
+        assert result["education"]["pass"] is True
 
-    def test_case_insensitive_matching(self):
-        """Test that matching is case insensitive"""
-        job_info = {
-            "salary_max": 180000,
-            "location_policy": "REMOTE",
-            "role_type": "ic",
-            "title": "STAFF SOFTWARE ENGINEER",
-        }
+    def test_user_below_requirement_fails(self):
+        prefs = JobPreferences(education_level="bachelor")
+        info = _full_match_info()
+        info["education_requirement"] = "phd"
+        result = evaluate_job_against_criteria(info, prefs)
+        assert result["education"]["pass"] is False
 
-        result = evaluate_job_against_criteria(job_info)
+    def test_none_requirement_passes(self):
+        prefs = JobPreferences(education_level="associate")
+        info = _full_match_info()
+        info["education_requirement"] = "none"
+        result = evaluate_job_against_criteria(info, prefs)
+        assert result["education"]["pass"] is True
 
-        assert result["remote"]["pass"] is True
-        assert result["title_level"]["pass"] is True
+
+class TestEquityAndBenefits:
+    def test_equity_no_preference_passes(self):
+        prefs = JobPreferences(acceptable_equity_types=[])
+        info = _full_match_info()
+        info["equity_offered"] = []
+        result = evaluate_job_against_criteria(info, prefs)
+        assert result["equity"]["pass"] is True
+
+    def test_equity_overlap_passes(self):
+        prefs = JobPreferences(acceptable_equity_types=["rsus"])
+        info = _full_match_info()
+        info["equity_offered"] = ["rsus", "stock_options"]
+        result = evaluate_job_against_criteria(info, prefs)
+        assert result["equity"]["pass"] is True
+
+    def test_benefits_missing_required_fails(self):
+        prefs = JobPreferences(required_benefits=["health", "401k"])
+        info = _full_match_info()
+        info["benefits_offered"] = ["health"]
+        result = evaluate_job_against_criteria(info, prefs)
+        assert result["benefits"]["pass"] is False
+
+
+class TestResultShape:
+    def test_each_result_has_required_keys(self):
+        result = evaluate_job_against_criteria(_full_match_info(), JobPreferences())
+        for criterion in result.values():
+            assert set(criterion) == {"pass", "reason", "mode", "extracted_value"}
+
+    def test_mode_reflects_config(self):
+        prefs = JobPreferences()
+        prefs.salary_config = CriterionConfig(mode="optional", none_policy="pass")
+        result = evaluate_job_against_criteria(_full_match_info(), prefs)
+        assert result["salary"]["mode"] == "optional"
+
+    def test_empty_info_returns_error(self):
+        assert "error" in evaluate_job_against_criteria({}, JobPreferences())

--- a/tests/unit/core/job_evaluation/test_evaluator.py
+++ b/tests/unit/core/job_evaluation/test_evaluator.py
@@ -46,11 +46,19 @@ class TestSalaryCriterion:
         result = evaluate_job_against_criteria(info, prefs)
         assert result["salary"]["pass"] is False
 
-    def test_missing_salary_respects_none_policy(self):
+    def test_missing_salary_defaults_to_pass(self):
         info = _full_match_info()
         info["salary_max"] = None
-        # Default salary none_policy is FAIL.
+        # Default salary none_policy is PASS (wide net).
         result = evaluate_job_against_criteria(info, JobPreferences())
+        assert result["salary"]["pass"] is True
+
+    def test_missing_salary_fails_with_fail_policy(self):
+        info = _full_match_info()
+        info["salary_max"] = None
+        prefs = JobPreferences()
+        prefs.salary_config = CriterionConfig(mode="required", none_policy="fail")
+        result = evaluate_job_against_criteria(info, prefs)
         assert result["salary"]["pass"] is False
 
 
@@ -69,11 +77,19 @@ class TestMembershipCriteria:
         result = evaluate_job_against_criteria(info, prefs)
         assert result["seniority"]["pass"] is False
 
-    def test_unclear_membership_respects_none_policy(self):
+    def test_unclear_membership_defaults_to_pass(self):
         info = _full_match_info()
         info["location_policy"] = "unclear"
-        # Default location none_policy is FAIL.
+        # Default location none_policy is PASS (wide net).
         result = evaluate_job_against_criteria(info, JobPreferences())
+        assert result["location"]["pass"] is True
+
+    def test_unclear_membership_fails_with_fail_policy(self):
+        info = _full_match_info()
+        info["location_policy"] = "unclear"
+        prefs = JobPreferences()
+        prefs.location_config = CriterionConfig(mode="required", none_policy="fail")
+        result = evaluate_job_against_criteria(info, prefs)
         assert result["location"]["pass"] is False
 
 

--- a/tests/unit/core/job_evaluation/test_fit_evaluator.py
+++ b/tests/unit/core/job_evaluation/test_fit_evaluator.py
@@ -57,3 +57,35 @@ class TestEvaluateFit:
 
         assert result["pass"] is False
         assert result["extracted_value"] == "poor_fit"
+
+    @patch("src.core.job_evaluation.fit_evaluator.get_chat_model_by_profile_name")
+    def test_llm_failure_falls_back_to_none_policy(self, mock_get_model):
+        """A transient LLM failure must not raise; it returns a graceful result."""
+        structured = Mock()
+        structured.invoke.side_effect = RuntimeError("503 service unavailable")
+        model = Mock()
+        model.with_structured_output.return_value = structured
+        mock_get_model.return_value = model
+
+        # Default fit none_policy is PASS.
+        prefs = JobPreferences(target_role_description="AI Engineer focused on LLMs")
+        result = evaluate_fit("some job text", prefs)
+
+        assert result["pass"] is True
+        assert "Fit assessment failed" in result["reason"]
+        assert result["extracted_value"] is None
+
+    @patch("src.core.job_evaluation.fit_evaluator.get_chat_model_by_profile_name")
+    def test_llm_failure_with_fail_none_policy(self, mock_get_model):
+        structured = Mock()
+        structured.invoke.side_effect = RuntimeError("boom")
+        model = Mock()
+        model.with_structured_output.return_value = structured
+        mock_get_model.return_value = model
+
+        prefs = JobPreferences(target_role_description="AI Engineer focused on LLMs")
+        prefs.fit_config = CriterionConfig(mode="required", none_policy="fail")
+        result = evaluate_fit("some job text", prefs)
+
+        assert result["pass"] is False
+        assert "Fit assessment failed" in result["reason"]

--- a/tests/unit/core/job_evaluation/test_fit_evaluator.py
+++ b/tests/unit/core/job_evaluation/test_fit_evaluator.py
@@ -89,3 +89,16 @@ class TestEvaluateFit:
 
         assert result["pass"] is False
         assert "Fit assessment failed" in result["reason"]
+
+    @patch("src.core.job_evaluation.fit_evaluator.get_chat_model_by_profile_name")
+    def test_model_construction_failure_does_not_raise(self, mock_get_model):
+        """A failure before the LLM call (e.g. provider ImportError) is caught too."""
+        mock_get_model.side_effect = ImportError("provider package missing")
+
+        # Default fit none_policy is PASS.
+        prefs = JobPreferences(target_role_description="AI Engineer focused on LLMs")
+        result = evaluate_fit("some job text", prefs)
+
+        assert result["pass"] is True
+        assert "Fit assessment failed" in result["reason"]
+        assert result["extracted_value"] is None

--- a/tests/unit/core/job_evaluation/test_fit_evaluator.py
+++ b/tests/unit/core/job_evaluation/test_fit_evaluator.py
@@ -1,0 +1,59 @@
+"""
+Unit tests for the LLM-based fit evaluator.
+"""
+
+from unittest.mock import Mock, patch
+
+from src.core.job_evaluation.fit_evaluator import FitAssessment, evaluate_fit
+from src.models.user import CriterionConfig, JobPreferences
+
+
+class TestEvaluateFit:
+    def test_skips_when_no_target_role(self):
+        """With no target role description, fit is not assessed (no LLM call)."""
+        prefs = JobPreferences(target_role_description="")
+        # Default fit none_policy is PASS.
+        result = evaluate_fit("some job text", prefs)
+        assert result["pass"] is True
+        assert result["extracted_value"] is None
+
+    def test_skip_respects_fail_none_policy(self):
+        prefs = JobPreferences(target_role_description="")
+        prefs.fit_config = CriterionConfig(mode="required", none_policy="fail")
+        result = evaluate_fit("some job text", prefs)
+        assert result["pass"] is False
+
+    @patch("src.core.job_evaluation.fit_evaluator.get_chat_model_by_profile_name")
+    def test_good_fit_passes(self, mock_get_model):
+        structured = Mock()
+        structured.invoke.return_value = FitAssessment(
+            verdict="good_fit", reasoning="Strong alignment with LLM focus"
+        )
+        model = Mock()
+        model.with_structured_output.return_value = structured
+        mock_get_model.return_value = model
+
+        prefs = JobPreferences(
+            target_role_description="AI Engineer focused on LLMs",
+            key_skills=["Python", "RAG"],
+        )
+        result = evaluate_fit("AI Engineer building RAG systems", prefs)
+
+        assert result["pass"] is True
+        assert result["extracted_value"] == "good_fit"
+
+    @patch("src.core.job_evaluation.fit_evaluator.get_chat_model_by_profile_name")
+    def test_poor_fit_fails(self, mock_get_model):
+        structured = Mock()
+        structured.invoke.return_value = FitAssessment(
+            verdict="poor_fit", reasoning="Role is A/B testing focused"
+        )
+        model = Mock()
+        model.with_structured_output.return_value = structured
+        mock_get_model.return_value = model
+
+        prefs = JobPreferences(target_role_description="AI Engineer focused on LLMs")
+        result = evaluate_fit("Data Scientist for A/B testing", prefs)
+
+        assert result["pass"] is False
+        assert result["extracted_value"] == "poor_fit"

--- a/tests/unit/core/job_evaluation/test_recommender.py
+++ b/tests/unit/core/job_evaluation/test_recommender.py
@@ -1,184 +1,67 @@
 """
 Unit tests for job recommendation core logic.
-
-This module tests the recommendation generation functionality
-in the core business logic layer.
 """
-
-import pytest
 
 from src.core.job_evaluation.recommender import generate_recommendation_from_evaluation
 
 
-class TestGenerateRecommendationFromEvaluation:
-    """Test the core recommendation generation function."""
+def _crit(passed, mode="required", reason="reason"):
+    return {"pass": passed, "reason": reason, "mode": mode, "extracted_value": None}
 
-    def test_all_criteria_passed_should_recommend_apply(self):
-        """Test recommendation when all criteria pass."""
-        evaluation_result = {
-            "salary": {"pass": True, "reason": "Salary meets requirement"},
-            "remote": {"pass": True, "reason": "Position is remote"},
-            "title_level": {
-                "pass": True,
-                "reason": "IC role has appropriate seniority",
-            },
+
+class TestGenerateRecommendation:
+    def test_all_required_pass_recommends_apply(self):
+        evaluation = {
+            "salary": _crit(True),
+            "location": _crit(True),
         }
+        rec, reasoning = generate_recommendation_from_evaluation(evaluation)
+        assert rec == "APPLY"
+        assert "All required criteria passed" in reasoning
 
-        recommendation, reasoning = generate_recommendation_from_evaluation(
-            evaluation_result
-        )
-
-        assert recommendation == "APPLY"
-        assert "All criteria passed" in reasoning
-        assert "salary: Salary meets requirement" in reasoning
-        assert "remote: Position is remote" in reasoning
-        assert "title_level: IC role has appropriate seniority" in reasoning
-
-    def test_some_criteria_failed_should_recommend_do_not_apply(self):
-        """Test recommendation when some criteria fail."""
-        evaluation_result = {
-            "salary": {"pass": True, "reason": "Salary meets requirement"},
-            "remote": {"pass": False, "reason": "Position is not remote"},
-            "title_level": {"pass": False, "reason": "IC role lacks seniority"},
+    def test_required_failure_blocks_apply(self):
+        evaluation = {
+            "salary": _crit(False, reason="Salary too low"),
+            "location": _crit(True),
         }
+        rec, reasoning = generate_recommendation_from_evaluation(evaluation)
+        assert rec == "DO_NOT_APPLY"
+        assert "Salary too low" in reasoning
 
-        recommendation, reasoning = generate_recommendation_from_evaluation(
-            evaluation_result
-        )
-
-        assert recommendation == "DO_NOT_APPLY"
-        assert "Failed criteria" in reasoning
-        assert "remote: Position is not remote" in reasoning
-        assert "title_level: IC role lacks seniority" in reasoning
-        assert (
-            "salary: Salary meets requirement" not in reasoning
-        )  # Only failed criteria in reasoning
-
-    def test_all_criteria_failed_should_recommend_do_not_apply(self):
-        """Test recommendation when all criteria fail."""
-        evaluation_result = {
-            "salary": {"pass": False, "reason": "Salary too low"},
-            "remote": {"pass": False, "reason": "Position is not remote"},
-            "title_level": {"pass": False, "reason": "IC role lacks seniority"},
+    def test_optional_failure_does_not_block(self):
+        """An optional criterion failing must not change APPLY."""
+        evaluation = {
+            "salary": _crit(True),
+            "benefits": _crit(False, mode="optional", reason="Missing dental"),
         }
+        rec, reasoning = generate_recommendation_from_evaluation(evaluation)
+        assert rec == "APPLY"
+        assert "Optional concerns" in reasoning
+        assert "Missing dental" in reasoning
 
-        recommendation, reasoning = generate_recommendation_from_evaluation(
-            evaluation_result
-        )
-
-        assert recommendation == "DO_NOT_APPLY"
-        assert "Failed criteria" in reasoning
-        assert "salary: Salary too low" in reasoning
-        assert "remote: Position is not remote" in reasoning
-        assert "title_level: IC role lacks seniority" in reasoning
-
-    def test_single_criterion_passed_should_recommend_do_not_apply(self):
-        """Test recommendation with only one criterion passing."""
-        evaluation_result = {
-            "salary": {"pass": True, "reason": "Salary meets requirement"},
-            "remote": {"pass": False, "reason": "Position is not remote"},
+    def test_required_failure_reports_optional_concerns_too(self):
+        evaluation = {
+            "salary": _crit(False, reason="Salary too low"),
+            "benefits": _crit(False, mode="optional", reason="Missing dental"),
         }
+        rec, reasoning = generate_recommendation_from_evaluation(evaluation)
+        assert rec == "DO_NOT_APPLY"
+        assert "Salary too low" in reasoning
+        assert "Missing dental" in reasoning
 
-        recommendation, reasoning = generate_recommendation_from_evaluation(
-            evaluation_result
-        )
+    def test_empty_returns_error(self):
+        rec, reasoning = generate_recommendation_from_evaluation({})
+        assert rec == "ERROR"
 
-        assert recommendation == "DO_NOT_APPLY"
-        assert "Failed criteria" in reasoning
-        assert "remote: Position is not remote" in reasoning
+    def test_error_key_returns_error(self):
+        rec, _ = generate_recommendation_from_evaluation({"error": "boom"})
+        assert rec == "ERROR"
 
-    def test_empty_evaluation_result_should_return_error(self):
-        """Test recommendation with empty evaluation result."""
-        recommendation, reasoning = generate_recommendation_from_evaluation({})
-
-        assert recommendation == "ERROR"
-        assert reasoning == "Unable to evaluate job posting"
-
-    def test_none_evaluation_result_should_return_error(self):
-        """Test recommendation with None evaluation result."""
-        recommendation, reasoning = generate_recommendation_from_evaluation(None)
-
-        assert recommendation == "ERROR"
-        assert reasoning == "Unable to evaluate job posting"
-
-    def test_evaluation_result_with_error_should_return_error(self):
-        """Test recommendation when evaluation result contains error."""
-        evaluation_result = {"error": "Evaluation failed"}
-
-        recommendation, reasoning = generate_recommendation_from_evaluation(
-            evaluation_result
-        )
-
-        assert recommendation == "ERROR"
-        assert reasoning == "Unable to evaluate job posting"
-
-    def test_malformed_evaluation_result_should_handle_gracefully(self):
-        """Test recommendation with malformed evaluation result."""
-        evaluation_result = {
-            "salary": {"pass": True, "reason": "Salary meets requirement"},
-            "malformed": "not a dict",  # Malformed criterion
-            "remote": {"pass": False, "reason": "Position is not remote"},
+    def test_malformed_entries_ignored(self):
+        evaluation = {
+            "salary": _crit(True),
+            "junk": "not a dict",
+            "missing_mode": {"pass": False, "reason": "x"},
         }
-
-        recommendation, reasoning = generate_recommendation_from_evaluation(
-            evaluation_result
-        )
-
-        # Should still work, ignoring malformed entries
-        assert recommendation == "DO_NOT_APPLY"
-        assert "Failed criteria" in reasoning
-        assert "remote: Position is not remote" in reasoning
-        assert "salary: Salary meets requirement" not in reasoning
-
-    def test_evaluation_result_missing_pass_field_should_handle_gracefully(self):
-        """Test recommendation with evaluation result missing 'pass' field."""
-        evaluation_result = {
-            "salary": {"reason": "Salary meets requirement"},  # Missing 'pass' field
-            "remote": {"pass": False, "reason": "Position is not remote"},
-        }
-
-        recommendation, reasoning = generate_recommendation_from_evaluation(
-            evaluation_result
-        )
-
-        # Should still work, ignoring malformed entries
-        assert recommendation == "DO_NOT_APPLY"
-        assert "Failed criteria" in reasoning
-        assert "remote: Position is not remote" in reasoning
-
-    def test_evaluation_result_with_no_valid_criteria_should_recommend_apply(self):
-        """Test recommendation when no valid criteria are found."""
-        evaluation_result = {
-            "malformed1": "not a dict",
-            "malformed2": {"reason": "missing pass field"},
-        }
-
-        recommendation, reasoning = generate_recommendation_from_evaluation(
-            evaluation_result
-        )
-
-        # If no valid criteria found, no failed criteria means APPLY
-        assert recommendation == "APPLY"
-        assert "All criteria passed" in reasoning
-
-    def test_mixed_valid_and_invalid_criteria_should_work_correctly(self):
-        """Test recommendation with mix of valid and invalid criteria."""
-        evaluation_result = {
-            "salary": {"pass": True, "reason": "Salary meets requirement"},
-            "invalid": "not a dict",
-            "remote": {"pass": False, "reason": "Position is not remote"},
-            "malformed": {"reason": "missing pass field"},
-            "title_level": {
-                "pass": True,
-                "reason": "IC role has appropriate seniority",
-            },
-        }
-
-        recommendation, reasoning = generate_recommendation_from_evaluation(
-            evaluation_result
-        )
-
-        assert recommendation == "DO_NOT_APPLY"
-        assert "Failed criteria" in reasoning
-        assert "remote: Position is not remote" in reasoning
-        # Should ignore invalid/malformed entries and only consider valid ones
+        rec, _ = generate_recommendation_from_evaluation(evaluation)
+        assert rec == "APPLY"

--- a/tests/unit/core/job_evaluation/test_recommender.py
+++ b/tests/unit/core/job_evaluation/test_recommender.py
@@ -26,7 +26,9 @@ class TestGenerateRecommendation:
         }
         rec, reasoning = generate_recommendation_from_evaluation(evaluation)
         assert rec == "DO_NOT_APPLY"
-        assert "Salary too low" in reasoning
+        # Reasoning is brief: lists failed criterion names, not full reasons
+        # (the breakdown UI shows the per-criterion reasons).
+        assert reasoning == "Required criteria failed: salary."
 
     def test_optional_failure_does_not_block(self):
         """An optional criterion failing must not change APPLY."""
@@ -37,7 +39,9 @@ class TestGenerateRecommendation:
         rec, reasoning = generate_recommendation_from_evaluation(evaluation)
         assert rec == "APPLY"
         assert "Optional concerns" in reasoning
-        assert "Missing dental" in reasoning
+        assert "benefits" in reasoning
+        # Full per-criterion reason text stays out of the recommender summary.
+        assert "Missing dental" not in reasoning
 
     def test_required_failure_reports_optional_concerns_too(self):
         evaluation = {
@@ -46,8 +50,18 @@ class TestGenerateRecommendation:
         }
         rec, reasoning = generate_recommendation_from_evaluation(evaluation)
         assert rec == "DO_NOT_APPLY"
-        assert "Salary too low" in reasoning
-        assert "Missing dental" in reasoning
+        assert "Required criteria failed: salary." in reasoning
+        assert "Optional concerns: benefits." in reasoning
+
+    def test_multiple_required_failures_listed_with_readable_names(self):
+        evaluation = {
+            "salary": _crit(False),
+            "employment_type": _crit(False),
+            "location": _crit(True),
+        }
+        _, reasoning = generate_recommendation_from_evaluation(evaluation)
+        # underscores normalized to spaces for readability
+        assert reasoning == "Required criteria failed: salary, employment type."
 
     def test_empty_returns_error(self):
         rec, reasoning = generate_recommendation_from_evaluation({})

--- a/tests/unit/core/test_preferences.py
+++ b/tests/unit/core/test_preferences.py
@@ -48,3 +48,15 @@ class TestPreferencesPersistence:
         path = tmp_path / "prefs.yaml"
         path.write_text("")
         assert load_preferences(path) == JobPreferences()
+
+    def test_partial_criterion_config_uses_pass_none_policy(self, tmp_path):
+        """Partial YAML with only `mode` set picks up the product-wide PASS default.
+
+        Regression guard: keeps CriterionConfig's class-level none_policy default
+        aligned with what every JobPreferences factory uses.
+        """
+        path = tmp_path / "prefs.yaml"
+        path.write_text("salary_config:\n  mode: required\n")
+        prefs = load_preferences(path)
+        assert prefs.salary_config.mode == "required"
+        assert prefs.salary_config.none_policy == "pass"

--- a/tests/unit/core/test_preferences.py
+++ b/tests/unit/core/test_preferences.py
@@ -1,0 +1,50 @@
+"""
+Unit tests for user preference persistence.
+"""
+
+from src.core.preferences import load_preferences, save_preferences
+from src.models.user import CriterionConfig, JobPreferences
+
+
+class TestPreferencesPersistence:
+    def test_load_missing_file_returns_defaults(self, tmp_path):
+        prefs = load_preferences(tmp_path / "does_not_exist.yaml")
+        assert prefs == JobPreferences()
+
+    def test_save_then_load_round_trip(self, tmp_path):
+        path = tmp_path / "prefs.yaml"
+        original = JobPreferences(
+            min_salary=140000,
+            acceptable_locations=["hybrid"],
+            company_blacklist=["Acme"],
+            target_role_description="ML Engineer",
+        )
+        original.salary_config = CriterionConfig(mode="optional", none_policy="pass")
+
+        save_preferences(original, path)
+        loaded = load_preferences(path)
+
+        assert loaded == original
+
+    def test_saved_yaml_uses_plain_strings(self, tmp_path):
+        path = tmp_path / "prefs.yaml"
+        save_preferences(JobPreferences(), path)
+        text = path.read_text()
+        # StrEnum values should be written as plain strings, not enum reprs.
+        assert "mode: required" in text
+        assert "CriterionMode" not in text
+
+    def test_malformed_yaml_falls_back_to_defaults(self, tmp_path):
+        path = tmp_path / "prefs.yaml"
+        path.write_text("min_salary: [unbalanced\n")
+        assert load_preferences(path) == JobPreferences()
+
+    def test_invalid_schema_falls_back_to_defaults(self, tmp_path):
+        path = tmp_path / "prefs.yaml"
+        path.write_text("acceptable_locations:\n  - work-from-moon\n")
+        assert load_preferences(path) == JobPreferences()
+
+    def test_empty_file_returns_defaults(self, tmp_path):
+        path = tmp_path / "prefs.yaml"
+        path.write_text("")
+        assert load_preferences(path) == JobPreferences()

--- a/tests/unit/models/test_models.py
+++ b/tests/unit/models/test_models.py
@@ -389,11 +389,27 @@ class TestJobPreferencesModel:
 
         assert prefs.min_salary == 100000
         assert prefs.acceptable_locations == ["remote"]
-        # Salary required by default; fit optional so first-run isn't broken.
         assert prefs.salary_config.mode == CriterionMode.REQUIRED
-        assert prefs.salary_config.none_policy == NonePolicy.FAIL
+        # Every criterion treats missing data as a pass by default (wide net).
+        all_configs = (
+            prefs.salary_config,
+            prefs.location_config,
+            prefs.level_config,
+            prefs.seniority_config,
+            prefs.visa_config,
+            prefs.blacklist_config,
+            prefs.employment_type_config,
+            prefs.travel_config,
+            prefs.education_config,
+            prefs.equity_config,
+            prefs.benefits_config,
+            prefs.fit_config,
+        )
+        assert all(cfg.none_policy == NonePolicy.PASS for cfg in all_configs)
+        # Mode defaults the user asked for.
+        assert prefs.seniority_config.mode == CriterionMode.OPTIONAL
+        assert prefs.employment_type_config.mode == CriterionMode.REQUIRED
         assert prefs.fit_config.mode == CriterionMode.OPTIONAL
-        assert prefs.fit_config.none_policy == NonePolicy.PASS
 
     def test_literal_validation_rejects_typos(self):
         """Invalid Literal values fail fast rather than silently never matching."""

--- a/tests/unit/models/test_models.py
+++ b/tests/unit/models/test_models.py
@@ -13,6 +13,7 @@ from src.models import (
     EvaluationResult,
     Experience,
     JobDescription,
+    JobPostingExtractionSchema,
     JobPreferences,
     JobSource,
     JobStatus,
@@ -426,6 +427,26 @@ class TestJobPreferencesModel:
 
         restored = JobPreferences.model_validate(data)
         assert restored == prefs
+
+
+class TestJobPostingExtractionSchema:
+    """Test the salary cross-field validation on the extraction schema."""
+
+    def test_valid_when_max_ge_min(self):
+        schema = JobPostingExtractionSchema(salary_min=100000, salary_max=150000)
+        assert schema.salary_max == 150000
+
+    def test_equal_min_max_is_valid(self):
+        schema = JobPostingExtractionSchema(salary_min=120000, salary_max=120000)
+        assert schema.salary_min == schema.salary_max
+
+    def test_max_below_min_raises(self):
+        with pytest.raises(ValidationError):
+            JobPostingExtractionSchema(salary_min=150000, salary_max=100000)
+
+    def test_only_one_bound_is_valid(self):
+        assert JobPostingExtractionSchema(salary_max=150000).salary_min is None
+        assert JobPostingExtractionSchema(salary_min=150000).salary_max is None
 
 
 class TestJobDescriptionModel:

--- a/tests/unit/models/test_models.py
+++ b/tests/unit/models/test_models.py
@@ -7,15 +7,17 @@ from pydantic import ValidationError
 
 from src.models import (
     BaseDataModel,
+    CriterionMode,
     Education,
     Environment,
     EvaluationResult,
     Experience,
     JobDescription,
+    JobPreferences,
     JobSource,
     JobStatus,
+    NonePolicy,
     Resume,
-    UserPreferences,
 )
 
 
@@ -378,38 +380,36 @@ class TestResumeModel:
         assert data == expected
 
 
-class TestUserPreferencesModel:
-    """Test the UserPreferences model."""
+class TestJobPreferencesModel:
+    """Test the JobPreferences model."""
 
-    def test_user_preferences_creation(self):
-        """Test UserPreferences model creation."""
-        job_titles = ["Software Engineer", "Data Scientist", "Product Manager"]
-        preferences = UserPreferences(job_titles=job_titles)
+    def test_defaults(self):
+        """A default JobPreferences is usable and has sensible criterion modes."""
+        prefs = JobPreferences()
 
-        assert preferences.job_titles == job_titles
+        assert prefs.min_salary == 100000
+        assert prefs.acceptable_locations == ["remote"]
+        # Salary required by default; fit optional so first-run isn't broken.
+        assert prefs.salary_config.mode == CriterionMode.REQUIRED
+        assert prefs.salary_config.none_policy == NonePolicy.FAIL
+        assert prefs.fit_config.mode == CriterionMode.OPTIONAL
+        assert prefs.fit_config.none_policy == NonePolicy.PASS
 
-    def test_user_preferences_missing_job_titles(self):
-        """Test UserPreferences validation with missing job_titles."""
-        with pytest.raises(ValidationError) as exc_info:
-            UserPreferences()
+    def test_literal_validation_rejects_typos(self):
+        """Invalid Literal values fail fast rather than silently never matching."""
+        with pytest.raises(ValidationError):
+            JobPreferences(acceptable_locations=["work-from-moon"])
 
-        errors = exc_info.value.errors()
-        missing_fields = {error["loc"][0] for error in errors}
-        assert "job_titles" in missing_fields
+    def test_json_round_trip_uses_plain_strings(self):
+        """model_dump(mode='json') writes enum values as plain strings."""
+        prefs = JobPreferences()
+        data = prefs.model_dump(mode="json")
 
-    def test_user_preferences_empty_job_titles(self):
-        """Test UserPreferences with empty job_titles list."""
-        preferences = UserPreferences(job_titles=[])
-        assert preferences.job_titles == []
+        assert data["salary_config"]["mode"] == "required"
+        assert data["fit_config"]["none_policy"] == "pass"
 
-    def test_user_preferences_serialization(self):
-        """Test UserPreferences model serialization."""
-        job_titles = ["Backend Developer", "DevOps Engineer"]
-        preferences = UserPreferences(job_titles=job_titles)
-
-        data = preferences.model_dump()
-        expected = {"job_titles": job_titles}
-        assert data == expected
+        restored = JobPreferences.model_validate(data)
+        assert restored == prefs
 
 
 class TestJobDescriptionModel:

--- a/tests/unit/models/test_models.py
+++ b/tests/unit/models/test_models.py
@@ -460,7 +460,7 @@ class TestJobDescriptionModel:
         assert job.title is None
         assert job.company is None
         assert job.description is None
-        assert job.is_remote is False
+        assert job.is_remote is None
         assert job.requirements == []
         assert job.source is None
         assert job.url is None

--- a/tests/unit/ui/test_job_results.py
+++ b/tests/unit/ui/test_job_results.py
@@ -1,0 +1,35 @@
+"""
+Unit tests for the job results display helpers.
+
+The render functions themselves are Streamlit-driven and exercised manually;
+this module covers the pure helpers.
+"""
+
+from ui.components.job_results import _criterion_icon, _escape_md
+
+
+class TestEscapeMd:
+    def test_dollars_are_escaped(self):
+        """Streamlit treats $...$ as LaTeX math; escape so dollars render literally."""
+        assert _escape_md("$100,000") == r"\$100,000"
+        assert _escape_md("$10 - $20") == r"\$10 - \$20"
+
+    def test_text_without_dollars_unchanged(self):
+        assert _escape_md("plain text") == "plain text"
+
+    def test_handles_non_string(self):
+        assert _escape_md(100) == "100"
+
+
+class TestCriterionIcon:
+    def test_required_pass(self):
+        assert _criterion_icon({"pass": True, "mode": "required"}) == "✅"
+
+    def test_required_fail(self):
+        assert _criterion_icon({"pass": False, "mode": "required"}) == "❌"
+
+    def test_optional_pass(self):
+        assert _criterion_icon({"pass": True, "mode": "optional"}) == "🟢"
+
+    def test_optional_fail(self):
+        assert _criterion_icon({"pass": False, "mode": "optional"}) == "🟡"

--- a/tests/unit/ui/test_settings_validation.py
+++ b/tests/unit/ui/test_settings_validation.py
@@ -6,10 +6,28 @@ pure validation helper is testable in isolation.
 """
 
 from ui.pages.settings import (
+    CRITERIA_CONFIGS,
     SALARY_TIERS,
+    _all_widget_keys,
     _salary_slider_options,
     _validate_required_lists,
 )
+
+
+class TestWidgetKeys:
+    def test_no_duplicate_keys(self):
+        keys = _all_widget_keys()
+        assert len(keys) == len(set(keys))
+
+    def test_every_criterion_has_mode_and_none_keys(self):
+        keys = set(_all_widget_keys())
+        for attr, _ in CRITERIA_CONFIGS:
+            assert f"{attr}_mode" in keys
+            assert f"{attr}_none" in keys
+
+    def test_includes_value_widget_keys(self):
+        keys = set(_all_widget_keys())
+        assert {"pref_min_salary", "pref_locations", "pref_key_skills"} <= keys
 
 
 class TestSalarySliderOptions:

--- a/tests/unit/ui/test_settings_validation.py
+++ b/tests/unit/ui/test_settings_validation.py
@@ -5,7 +5,31 @@ The Settings page itself is Streamlit-driven and exercised manually, but the
 pure validation helper is testable in isolation.
 """
 
-from ui.pages.settings import _validate_required_lists
+from ui.pages.settings import (
+    SALARY_TIERS,
+    _salary_slider_options,
+    _validate_required_lists,
+)
+
+
+class TestSalarySliderOptions:
+    def test_persisted_tier_value_keeps_tiers(self):
+        assert _salary_slider_options(100000) == sorted(SALARY_TIERS)
+
+    def test_non_tier_value_is_included_and_sorted(self):
+        options = _salary_slider_options(90000)
+        assert 90000 in options
+        assert options == sorted(options)
+        # The fixed tiers are still present.
+        assert set(SALARY_TIERS).issubset(options)
+
+    def test_value_above_range_is_included(self):
+        options = _salary_slider_options(300000)
+        assert options[-1] == 300000
+
+    def test_no_duplicate_when_value_is_a_tier(self):
+        options = _salary_slider_options(60000)
+        assert options.count(60000) == 1
 
 
 class TestValidateRequiredLists:

--- a/tests/unit/ui/test_settings_validation.py
+++ b/tests/unit/ui/test_settings_validation.py
@@ -1,0 +1,33 @@
+"""
+Unit tests for the Settings page validation helper.
+
+The Settings page itself is Streamlit-driven and exercised manually, but the
+pure validation helper is testable in isolation.
+"""
+
+from ui.pages.settings import _validate_required_lists
+
+
+class TestValidateRequiredLists:
+    def test_all_populated_returns_no_errors(self):
+        errors = _validate_required_lists(
+            acceptable_locations=["remote"],
+            acceptable_employment_types=["full-time"],
+            acceptable_levels=["ic"],
+            acceptable_seniority=["senior"],
+        )
+        assert errors == []
+
+    def test_each_empty_list_reports_one_error(self):
+        errors = _validate_required_lists(
+            acceptable_locations=[],
+            acceptable_employment_types=["full-time"],
+            acceptable_levels=["ic"],
+            acceptable_seniority=["senior"],
+        )
+        assert len(errors) == 1
+        assert "location" in errors[0]
+
+    def test_all_empty_reports_all_errors(self):
+        errors = _validate_required_lists([], [], [], [])
+        assert len(errors) == 4

--- a/tests/unit/utils/test_text.py
+++ b/tests/unit/utils/test_text.py
@@ -1,0 +1,25 @@
+"""
+Unit tests for text utilities.
+"""
+
+from src.utils.text import truncate_text
+
+
+class TestTruncateText:
+    def test_within_limit_unchanged(self):
+        text = "short text"
+        assert truncate_text(text, 100) == text
+
+    def test_over_limit_truncated_with_marker(self):
+        text = "a" * 50
+        result = truncate_text(text, 10, "job posting")
+        assert result.startswith("a" * 10)
+        assert result.endswith("[truncated]")
+        assert len(result) <= 10 + len("\n[truncated]")
+
+    def test_exact_limit_unchanged(self):
+        text = "a" * 10
+        assert truncate_text(text, 10) == text
+
+    def test_none_passthrough(self):
+        assert truncate_text(None, 10) is None

--- a/ui/components/job_results.py
+++ b/ui/components/job_results.py
@@ -32,6 +32,17 @@ def _criterion_icon(result: Dict[str, Any]) -> str:
     return "❌" if required else "🟡"
 
 
+def _escape_md(text: str) -> str:
+    """Escape ``$`` so Streamlit's markdown doesn't render it as LaTeX math.
+
+    Streamlit interprets ``$...$`` as inline math, which silently strips the
+    dollar signs and italicizes the digits ("$100,000 meets $200,000" renders
+    as "100,000 meets 200,000" in math italics). Escape to ``\\$`` so dollars
+    render literally.
+    """
+    return str(text).replace("$", r"\$")
+
+
 def _display_extracted_info(extracted_info: Dict[str, Any]) -> None:
     """Render the structured fields extracted from the posting."""
     st.subheader("📋 Extracted Job Information")
@@ -60,11 +71,11 @@ def _display_extracted_info(extracted_info: Dict[str, Any]) -> None:
         salary_min = extracted_info.get("salary_min")
         salary_max = extracted_info.get("salary_max")
         if salary_min and salary_max:
-            st.write(f"**Salary:** ${salary_min:,} - ${salary_max:,}")
+            st.write(_escape_md(f"**Salary:** ${salary_min:,} - ${salary_max:,}"))
         elif salary_max:
-            st.write(f"**Salary:** Up to ${salary_max:,}")
+            st.write(_escape_md(f"**Salary:** Up to ${salary_max:,}"))
         elif salary_min:
-            st.write(f"**Salary:** From ${salary_min:,}")
+            st.write(_escape_md(f"**Salary:** From ${salary_min:,}"))
 
         visa = extracted_info.get("visa_sponsorship")
         if visa and visa != "unclear":
@@ -92,7 +103,8 @@ def _display_criteria(evaluation_result: Dict[str, Any]) -> None:
             continue
         label = CRITERION_LABELS.get(key, key.replace("_", " ").title())
         icon = _criterion_icon(result)
-        st.write(f"{icon} **{label}:** {result.get('reason', '')}")
+        reason = _escape_md(result.get("reason", ""))
+        st.write(f"{icon} **{label}:** {reason}")
 
 
 def display_job_evaluation_results(results: Dict[str, Any]) -> None:
@@ -104,10 +116,10 @@ def display_job_evaluation_results(results: Dict[str, Any]) -> None:
 
     if recommendation == "APPLY":
         st.success(f"🎯 **Recommendation: {recommendation}**")
-        st.success(f"**Reasoning:** {reasoning}")
+        st.success(_escape_md(f"**Reasoning:** {reasoning}"))
     else:
         st.error(f"❌ **Recommendation: {recommendation}**")
-        st.error(f"**Reasoning:** {reasoning}")
+        st.error(_escape_md(f"**Reasoning:** {reasoning}"))
 
     if evaluation_result:
         _display_criteria(evaluation_result)

--- a/ui/components/job_results.py
+++ b/ui/components/job_results.py
@@ -1,19 +1,107 @@
 """
-Job evaluation results display component
+Job evaluation results display component.
 """
 
 from typing import Any, Dict
 
 import streamlit as st
 
+# Human-readable labels for the criteria keys produced by the evaluator.
+CRITERION_LABELS = {
+    "salary": "Salary",
+    "location": "Location",
+    "level": "Role Type",
+    "seniority": "Seniority",
+    "visa": "Visa Sponsorship",
+    "blacklist": "Company Blacklist",
+    "employment_type": "Employment Type",
+    "travel": "Travel",
+    "education": "Education",
+    "equity": "Equity",
+    "benefits": "Benefits",
+    "fit": "Fit",
+}
+
+
+def _criterion_icon(result: Dict[str, Any]) -> str:
+    """Pick an icon based on pass/fail and required/optional mode."""
+    passed = result.get("pass")
+    required = result.get("mode") == "required"
+    if passed:
+        return "✅" if required else "🟢"
+    return "❌" if required else "🟡"
+
+
+def _display_extracted_info(extracted_info: Dict[str, Any]) -> None:
+    """Render the structured fields extracted from the posting."""
+    st.subheader("📋 Extracted Job Information")
+    col1, col2 = st.columns(2)
+
+    with col1:
+        if extracted_info.get("title"):
+            st.write(f"**Title:** {extracted_info['title']}")
+        if extracted_info.get("company"):
+            st.write(f"**Company:** {extracted_info['company']}")
+        location = extracted_info.get("location_policy")
+        if location and location != "unclear":
+            st.write(f"**Location:** {location.title()}")
+        role_type = extracted_info.get("role_type")
+        if role_type and role_type != "unclear":
+            role_display = "Individual Contributor" if role_type == "ic" else "Manager"
+            st.write(f"**Role Type:** {role_display}")
+        seniority = extracted_info.get("seniority_level")
+        if seniority and seniority != "unclear":
+            st.write(f"**Seniority:** {seniority.title()}")
+        employment = extracted_info.get("employment_type")
+        if employment and employment != "unclear":
+            st.write(f"**Employment Type:** {employment.title()}")
+
+    with col2:
+        salary_min = extracted_info.get("salary_min")
+        salary_max = extracted_info.get("salary_max")
+        if salary_min and salary_max:
+            st.write(f"**Salary:** ${salary_min:,} - ${salary_max:,}")
+        elif salary_max:
+            st.write(f"**Salary:** Up to ${salary_max:,}")
+        elif salary_min:
+            st.write(f"**Salary:** From ${salary_min:,}")
+
+        visa = extracted_info.get("visa_sponsorship")
+        if visa and visa != "unclear":
+            st.write(f"**Visa Sponsorship:** {visa.title()}")
+        travel = extracted_info.get("travel_required")
+        if travel and travel != "unclear":
+            st.write(f"**Travel Required:** {travel.title()}")
+        education = extracted_info.get("education_requirement")
+        if education and education != "unclear":
+            st.write(f"**Education Required:** {education.title()}")
+        equity = extracted_info.get("equity_offered")
+        if equity:
+            st.write(f"**Equity:** {', '.join(equity)}")
+        benefits = extracted_info.get("benefits_offered")
+        if benefits:
+            st.write(f"**Benefits:** {', '.join(benefits)}")
+
+
+def _display_criteria(evaluation_result: Dict[str, Any]) -> None:
+    """Render each criterion result with a pass/fail and required/optional badge."""
+    st.subheader("🧮 Criteria Breakdown")
+    st.caption("✅ required pass  ❌ required fail  🟢 optional pass  🟡 optional fail")
+    for key, result in evaluation_result.items():
+        if not isinstance(result, dict) or "pass" not in result:
+            continue
+        label = CRITERION_LABELS.get(key, key.replace("_", " ").title())
+        icon = _criterion_icon(result)
+        st.write(f"{icon} **{label}:** {result.get('reason', '')}")
+
 
 def display_job_evaluation_results(results: Dict[str, Any]) -> None:
-    """Display job evaluation results in a formatted way"""
+    """Display job evaluation results in a formatted way."""
     recommendation = results.get("recommendation", "Unknown")
     reasoning = results.get("reasoning", "No reasoning provided")
     extracted_info = results.get("extracted_info", {})
+    evaluation_result = results.get("evaluation_result", {})
 
-    # Display recommendation with color coding
     if recommendation == "APPLY":
         st.success(f"🎯 **Recommendation: {recommendation}**")
         st.success(f"**Reasoning:** {reasoning}")
@@ -21,44 +109,8 @@ def display_job_evaluation_results(results: Dict[str, Any]) -> None:
         st.error(f"❌ **Recommendation: {recommendation}**")
         st.error(f"**Reasoning:** {reasoning}")
 
-    # Display extracted information
+    if evaluation_result:
+        _display_criteria(evaluation_result)
+
     if extracted_info:
-        st.subheader("📋 Extracted Job Information")
-
-        # Create columns for better layout
-        col1, col2 = st.columns(2)
-
-        with col1:
-            if "job_title" in extracted_info:
-                st.write(f"**Job Title:** {extracted_info['job_title']}")
-            if "company_name" in extracted_info:
-                st.write(f"**Company:** {extracted_info['company_name']}")
-            if "location" in extracted_info:
-                st.write(f"**Location:** {extracted_info['location']}")
-            if "work_type" in extracted_info:
-                st.write(f"**Work Type:** {extracted_info['work_type']}")
-
-        with col2:
-            if "salary_range" in extracted_info:
-                salary = extracted_info["salary_range"]
-                if isinstance(salary, dict):
-                    min_sal = salary.get("min", "N/A")
-                    max_sal = salary.get("max", "N/A")
-                    st.write(f"**Salary Range:** ${min_sal} - ${max_sal}")
-                else:
-                    st.write(f"**Salary Range:** {salary}")
-
-            if "experience_level" in extracted_info:
-                exp_level = extracted_info["experience_level"]
-                st.write(f"**Experience Level:** {exp_level}")
-            if "employment_type" in extracted_info:
-                emp_type = extracted_info["employment_type"]
-                st.write(f"**Employment Type:** {emp_type}")
-
-        # Display skills if available
-        if "required_skills" in extracted_info:
-            skills = extracted_info["required_skills"]
-            if isinstance(skills, list):
-                st.write(f"**Required Skills:** {', '.join(skills)}")
-            else:
-                st.write(f"**Required Skills:** {skills}")
+        _display_extracted_info(extracted_info)

--- a/ui/pages/job_evaluation.py
+++ b/ui/pages/job_evaluation.py
@@ -19,11 +19,8 @@ def render_job_evaluation_page():
     Paste a job description below and our AI will analyze if it's a good fit
     based on your preferences.
 
-    **Current evaluation criteria:**
-    - 💰 Salary range ($100,000+ preferred)
-    - 🏠 Remote work availability
-    - 📊 Experience level match
-    - 🛠️ Technical skills alignment
+    Configure what to evaluate (salary, location, seniority, visa, benefits,
+    fit, and more) on the **⚙️ Job Preferences** page.
     """)
 
     # Job description input

--- a/ui/pages/settings.py
+++ b/ui/pages/settings.py
@@ -72,6 +72,16 @@ def _multiselect(label, options_map, current, help_text=None):
     return [label_to_value[s] for s in selected]
 
 
+def _salary_slider_options(persisted: int) -> list:
+    """Return the salary tier options, always including the persisted value.
+
+    Folding the persisted value in (rather than indexing into a fixed list)
+    means a hand-edited or out-of-tier salary is shown as-is instead of being
+    silently clamped to a default tier on the next save.
+    """
+    return sorted(set(SALARY_TIERS) | {persisted})
+
+
 def _validate_required_lists(
     acceptable_locations: list,
     acceptable_employment_types: list,
@@ -107,13 +117,10 @@ def render_settings_page():
     prefs = load_preferences()
 
     st.subheader("💰 Compensation")
-    salary_index = (
-        SALARY_TIERS.index(prefs.min_salary) if prefs.min_salary in SALARY_TIERS else 2
-    )
     min_salary = st.select_slider(
         "Minimum yearly salary",
-        options=SALARY_TIERS,
-        value=SALARY_TIERS[salary_index],
+        options=_salary_slider_options(prefs.min_salary),
+        value=prefs.min_salary,
         format_func=lambda v: f"${v:,}",
     )
     acceptable_equity_types = _multiselect(

--- a/ui/pages/settings.py
+++ b/ui/pages/settings.py
@@ -63,13 +63,44 @@ CRITERIA_CONFIGS = [
 ]
 
 
-def _multiselect(label, options_map, current, help_text=None):
+def _multiselect(label, options_map, current, help_text=None, key=None):
     """Render a multiselect using display labels; return selected internal values."""
     labels = list(options_map.values())
     label_to_value = {v: k for k, v in options_map.items()}
     default_labels = [options_map[v] for v in current if v in options_map]
-    selected = st.multiselect(label, labels, default=default_labels, help=help_text)
+    selected = st.multiselect(
+        label, labels, default=default_labels, help=help_text, key=key
+    )
     return [label_to_value[s] for s in selected]
+
+
+# session_state keys for the value widgets. The advanced-config widget keys are
+# derived from CRITERIA_CONFIGS. All are cleared on "Reset to Defaults" so the
+# widgets re-initialize from the freshly written defaults instead of showing the
+# user's prior selections (Streamlit persists keyed widget state across reruns).
+_VALUE_WIDGET_KEYS = [
+    "pref_min_salary",
+    "pref_equity",
+    "pref_benefits",
+    "pref_locations",
+    "pref_travel",
+    "pref_employment",
+    "pref_levels",
+    "pref_seniority",
+    "pref_education",
+    "pref_visa",
+    "pref_blacklist",
+    "pref_target_role",
+    "pref_key_skills",
+]
+
+
+def _all_widget_keys() -> list:
+    """All session_state keys used by the settings widgets (value + advanced)."""
+    keys = list(_VALUE_WIDGET_KEYS)
+    for attr, _ in CRITERIA_CONFIGS:
+        keys.extend((f"{attr}_mode", f"{attr}_none"))
+    return keys
 
 
 def _salary_slider_options(persisted: int) -> list:
@@ -122,39 +153,52 @@ def render_settings_page():
         options=_salary_slider_options(prefs.min_salary),
         value=prefs.min_salary,
         format_func=lambda v: f"${v:,}",
+        key="pref_min_salary",
     )
     acceptable_equity_types = _multiselect(
         "Acceptable equity types",
         EQUITY_LABELS,
         prefs.acceptable_equity_types,
         "Leave empty if you have no equity preference.",
+        key="pref_equity",
     )
     required_benefits = _multiselect(
         "Required benefits",
         BENEFIT_LABELS,
         prefs.required_benefits,
         "Leave empty if you have no benefits requirement.",
+        key="pref_benefits",
     )
 
     st.subheader("🏢 Work Arrangement")
     acceptable_locations = _multiselect(
-        "Acceptable locations", LOCATION_LABELS, prefs.acceptable_locations
+        "Acceptable locations",
+        LOCATION_LABELS,
+        prefs.acceptable_locations,
+        key="pref_locations",
     )
     willing_to_travel = st.toggle(
-        "I'm willing to travel", value=prefs.willing_to_travel
+        "I'm willing to travel", value=prefs.willing_to_travel, key="pref_travel"
     )
     acceptable_employment_types = _multiselect(
         "Acceptable employment types",
         EMPLOYMENT_LABELS,
         prefs.acceptable_employment_types,
+        key="pref_employment",
     )
 
     st.subheader("📋 Requirements")
     acceptable_levels = _multiselect(
-        "Acceptable role types", LEVEL_LABELS, prefs.acceptable_levels
+        "Acceptable role types",
+        LEVEL_LABELS,
+        prefs.acceptable_levels,
+        key="pref_levels",
     )
     acceptable_seniority = _multiselect(
-        "Acceptable seniority levels", SENIORITY_LABELS, prefs.acceptable_seniority
+        "Acceptable seniority levels",
+        SENIORITY_LABELS,
+        prefs.acceptable_seniority,
+        key="pref_seniority",
     )
     education_values = list(EDUCATION_LABELS.keys())
     education_level = st.selectbox(
@@ -162,14 +206,18 @@ def render_settings_page():
         education_values,
         index=education_values.index(prefs.education_level),
         format_func=lambda v: EDUCATION_LABELS[v],
+        key="pref_education",
     )
     visa_sponsorship_required = st.toggle(
-        "I require visa sponsorship", value=prefs.visa_sponsorship_required
+        "I require visa sponsorship",
+        value=prefs.visa_sponsorship_required,
+        key="pref_visa",
     )
     blacklist_text = st.text_area(
         "Company blacklist (one per line)",
         value="\n".join(prefs.company_blacklist),
         help="Postings from these companies will fail the blacklist check.",
+        key="pref_blacklist",
     )
     company_blacklist = [
         line.strip() for line in blacklist_text.splitlines() if line.strip()
@@ -183,11 +231,13 @@ def render_settings_page():
             "e.g. AI/ML Engineer focused on LLMs, RAG, and production ML systems"
         ),
         help="Used by the AI fit assessment. Leave empty to skip fit evaluation.",
+        key="pref_target_role",
     )
     key_skills_text = st.text_input(
         "Key skills (comma-separated)",
         value=", ".join(prefs.key_skills),
         placeholder="Python, PyTorch, LangChain, RAG",
+        key="pref_key_skills",
     )
     key_skills = [s.strip() for s in key_skills_text.split(",") if s.strip()]
 
@@ -260,4 +310,8 @@ def render_settings_page():
     with col_reset:
         if st.button("↺ Reset to Defaults", use_container_width=True):
             save_preferences(JobPreferences())
+            # Clear persisted widget state so the inputs re-initialize from the
+            # freshly written defaults instead of the user's prior selections.
+            for key in _all_widget_keys():
+                st.session_state.pop(key, None)
             st.rerun()

--- a/ui/pages/settings.py
+++ b/ui/pages/settings.py
@@ -72,6 +72,30 @@ def _multiselect(label, options_map, current, help_text=None):
     return [label_to_value[s] for s in selected]
 
 
+def _validate_required_lists(
+    acceptable_locations: list,
+    acceptable_employment_types: list,
+    acceptable_levels: list,
+    acceptable_seniority: list,
+) -> list[str]:
+    """Return human-readable error messages for empty membership lists.
+
+    These four criteria are list-membership checks. An empty list combined
+    with any stated value in the posting always produces a fail, which is
+    never what the user wants -- so we require at least one selection.
+    """
+    errors = []
+    if not acceptable_locations:
+        errors.append("at least one acceptable location")
+    if not acceptable_employment_types:
+        errors.append("at least one acceptable employment type")
+    if not acceptable_levels:
+        errors.append("at least one acceptable role type")
+    if not acceptable_seniority:
+        errors.append("at least one acceptable seniority level")
+    return errors
+
+
 def render_settings_page():
     """Render the job preferences settings page."""
     st.header("⚙️ Job Preferences")
@@ -190,9 +214,23 @@ def render_settings_page():
                 )
             criteria_configs[attr] = CriterionConfig(mode=mode, none_policy=none_policy)
 
+    validation_errors = _validate_required_lists(
+        acceptable_locations,
+        acceptable_employment_types,
+        acceptable_levels,
+        acceptable_seniority,
+    )
+    if validation_errors:
+        st.error("Please select " + "; ".join(validation_errors) + " before saving.")
+
     col_save, col_reset = st.columns([1, 1])
     with col_save:
-        if st.button("💾 Save Preferences", type="primary", use_container_width=True):
+        if st.button(
+            "💾 Save Preferences",
+            type="primary",
+            use_container_width=True,
+            disabled=bool(validation_errors),
+        ):
             new_prefs = JobPreferences(
                 min_salary=min_salary,
                 acceptable_locations=acceptable_locations,

--- a/ui/pages/settings.py
+++ b/ui/pages/settings.py
@@ -1,26 +1,218 @@
 """
-Settings page for user preferences and configuration
+Settings page: job evaluation preferences.
+
+Lets the user configure the preferences used by the job evaluation workflow and
+persists them to a local YAML file.
 """
 
 import streamlit as st
 
+from src.core.preferences import load_preferences, save_preferences
+from src.models.user import CriterionConfig, JobPreferences
+
+SALARY_TIERS = [60000, 80000, 100000, 120000, 140000, 160000, 180000, 200000]
+
+LOCATION_LABELS = {"onsite": "On-site", "remote": "Remote", "hybrid": "Hybrid"}
+LEVEL_LABELS = {"ic": "Individual Contributor", "manager": "Manager"}
+SENIORITY_LABELS = {
+    "junior": "Junior",
+    "mid": "Mid",
+    "senior": "Senior",
+    "staff": "Staff",
+    "principal": "Principal",
+    "lead": "Lead",
+}
+EMPLOYMENT_LABELS = {
+    "full-time": "Full-time",
+    "part-time": "Part-time",
+    "contract": "Contract",
+    "internship": "Internship",
+}
+EQUITY_LABELS = {"stock_options": "Stock Options", "rsus": "RSUs"}
+BENEFIT_LABELS = {
+    "health": "Health/Medical",
+    "vision": "Vision",
+    "dental": "Dental",
+    "life": "Life",
+    "std": "STD",
+    "ltd": "LTD",
+    "401k": "401K",
+    "pto": "PTO",
+}
+EDUCATION_LABELS = {
+    "associate": "Associate Degree",
+    "bachelor": "Bachelor's Degree",
+    "master": "Master's Degree",
+    "phd": "PhD",
+}
+
+# (config attribute, display label) for the per-criterion advanced settings.
+CRITERIA_CONFIGS = [
+    ("salary_config", "Salary"),
+    ("location_config", "Location"),
+    ("level_config", "Role Type"),
+    ("seniority_config", "Seniority"),
+    ("visa_config", "Visa Sponsorship"),
+    ("blacklist_config", "Company Blacklist"),
+    ("employment_type_config", "Employment Type"),
+    ("travel_config", "Travel"),
+    ("education_config", "Education"),
+    ("equity_config", "Equity"),
+    ("benefits_config", "Benefits"),
+    ("fit_config", "Fit"),
+]
+
+
+def _multiselect(label, options_map, current, help_text=None):
+    """Render a multiselect using display labels; return selected internal values."""
+    labels = list(options_map.values())
+    label_to_value = {v: k for k, v in options_map.items()}
+    default_labels = [options_map[v] for v in current if v in options_map]
+    selected = st.multiselect(label, labels, default=default_labels, help=help_text)
+    return [label_to_value[s] for s in selected]
+
 
 def render_settings_page():
-    """Render the settings page content"""
-    st.header("⚙️ Settings")
-    st.info(
-        "🚧 **Coming Soon!** User preferences and resume management "
-        "will be available here."
+    """Render the job preferences settings page."""
+    st.header("⚙️ Job Preferences")
+    st.markdown(
+        "Configure how job postings are evaluated. Preferences are saved "
+        "locally and used the next time you evaluate a job."
     )
 
-    st.subheader("📋 Current Evaluation Criteria")
-    st.markdown("""
-    The job evaluation currently uses these built-in criteria:
+    prefs = load_preferences()
 
-    - **💰 Minimum Salary:** $100,000/year
-    - **🏠 Work Location:** Remote preferred
-    - **📊 Experience Level:** 3-8 years preferred
-    - **🛠️ Technical Skills:** Python, ML, Data Science focus
+    st.subheader("💰 Compensation")
+    salary_index = (
+        SALARY_TIERS.index(prefs.min_salary) if prefs.min_salary in SALARY_TIERS else 2
+    )
+    min_salary = st.select_slider(
+        "Minimum yearly salary",
+        options=SALARY_TIERS,
+        value=SALARY_TIERS[salary_index],
+        format_func=lambda v: f"${v:,}",
+    )
+    acceptable_equity_types = _multiselect(
+        "Acceptable equity types",
+        EQUITY_LABELS,
+        prefs.acceptable_equity_types,
+        "Leave empty if you have no equity preference.",
+    )
+    required_benefits = _multiselect(
+        "Required benefits",
+        BENEFIT_LABELS,
+        prefs.required_benefits,
+        "Leave empty if you have no benefits requirement.",
+    )
 
-    *Customizable preferences will be available in a future update.*
-    """)
+    st.subheader("🏢 Work Arrangement")
+    acceptable_locations = _multiselect(
+        "Acceptable locations", LOCATION_LABELS, prefs.acceptable_locations
+    )
+    willing_to_travel = st.toggle(
+        "I'm willing to travel", value=prefs.willing_to_travel
+    )
+    acceptable_employment_types = _multiselect(
+        "Acceptable employment types",
+        EMPLOYMENT_LABELS,
+        prefs.acceptable_employment_types,
+    )
+
+    st.subheader("📋 Requirements")
+    acceptable_levels = _multiselect(
+        "Acceptable role types", LEVEL_LABELS, prefs.acceptable_levels
+    )
+    acceptable_seniority = _multiselect(
+        "Acceptable seniority levels", SENIORITY_LABELS, prefs.acceptable_seniority
+    )
+    education_values = list(EDUCATION_LABELS.keys())
+    education_level = st.selectbox(
+        "Your highest education level",
+        education_values,
+        index=education_values.index(prefs.education_level),
+        format_func=lambda v: EDUCATION_LABELS[v],
+    )
+    visa_sponsorship_required = st.toggle(
+        "I require visa sponsorship", value=prefs.visa_sponsorship_required
+    )
+    blacklist_text = st.text_area(
+        "Company blacklist (one per line)",
+        value="\n".join(prefs.company_blacklist),
+        help="Postings from these companies will fail the blacklist check.",
+    )
+    company_blacklist = [
+        line.strip() for line in blacklist_text.splitlines() if line.strip()
+    ]
+
+    st.subheader("🎯 Fit")
+    target_role_description = st.text_area(
+        "Target role description",
+        value=prefs.target_role_description,
+        placeholder=(
+            "e.g. AI/ML Engineer focused on LLMs, RAG, and production ML systems"
+        ),
+        help="Used by the AI fit assessment. Leave empty to skip fit evaluation.",
+    )
+    key_skills_text = st.text_input(
+        "Key skills (comma-separated)",
+        value=", ".join(prefs.key_skills),
+        placeholder="Python, PyTorch, LangChain, RAG",
+    )
+    key_skills = [s.strip() for s in key_skills_text.split(",") if s.strip()]
+
+    # Collect per-criterion mode / none-handling configuration.
+    criteria_configs = {}
+    with st.expander("🔧 Advanced Configuration", expanded=False):
+        st.caption(
+            "Mark each criterion as required (must pass to recommend APPLY) or "
+            "optional, and choose how to treat a posting that doesn't mention it."
+        )
+        for attr, label in CRITERIA_CONFIGS:
+            current = getattr(prefs, attr)
+            col1, col2 = st.columns(2)
+            with col1:
+                mode = st.selectbox(
+                    f"{label} — mode",
+                    ["required", "optional"],
+                    index=["required", "optional"].index(current.mode.value),
+                    format_func=str.capitalize,
+                    key=f"{attr}_mode",
+                )
+            with col2:
+                none_policy = st.selectbox(
+                    f"{label} — if not in posting",
+                    ["pass", "fail"],
+                    index=["pass", "fail"].index(current.none_policy.value),
+                    format_func=lambda v: (
+                        "Count as pass" if v == "pass" else "Count as fail"
+                    ),
+                    key=f"{attr}_none",
+                )
+            criteria_configs[attr] = CriterionConfig(mode=mode, none_policy=none_policy)
+
+    col_save, col_reset = st.columns([1, 1])
+    with col_save:
+        if st.button("💾 Save Preferences", type="primary", use_container_width=True):
+            new_prefs = JobPreferences(
+                min_salary=min_salary,
+                acceptable_locations=acceptable_locations,
+                acceptable_levels=acceptable_levels,
+                acceptable_seniority=acceptable_seniority,
+                visa_sponsorship_required=visa_sponsorship_required,
+                company_blacklist=company_blacklist,
+                acceptable_employment_types=acceptable_employment_types,
+                willing_to_travel=willing_to_travel,
+                education_level=education_level,
+                acceptable_equity_types=acceptable_equity_types,
+                required_benefits=required_benefits,
+                target_role_description=target_role_description,
+                key_skills=key_skills,
+                **criteria_configs,
+            )
+            save_preferences(new_prefs)
+            st.success("Preferences saved.")
+
+    with col_reset:
+        if st.button("↺ Reset to Defaults", use_container_width=True):
+            save_preferences(JobPreferences())
+            st.rerun()

--- a/uv.lock
+++ b/uv.lock
@@ -1316,6 +1316,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pytest" },
     { name = "python-dotenv" },
+    { name = "pyyaml" },
     { name = "streamlit" },
 ]
 
@@ -1357,6 +1358,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7.1.0" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
+    { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "streamlit", specifier = ">=1.57.0" },
 ]
 provides-extras = ["dev", "presidio"]


### PR DESCRIPTION
Add user-configurable job evaluation preferences with YAML persistence, expanded extraction and rule-based checks, and an optional LLM fit assessment.

- Introduce `JobPreferences` with 12 criteria (salary, location, level, seniority, visa, blacklist, employment type, travel, education, equity, benefits, fit) and per-criterion required/optional plus none-handling
- Persist preferences to `data/user_preferences.yaml` and load them at workflow start via a new `load_preferences` node
- Expand `JobPostingExtractionSchema` and extraction prompt (including highest salary range when multiple exist)
- Refactor evaluator and recommender so only required criterion failures block APPLY; add LLM-based fit evaluation when a target role description is set
- Replace Settings stub with a full preferences UI and update job results to show criteria breakdown with required/optional badges
- Remove TOML `evaluation_criteria` in favor of user preferences; add `pyyaml` and text truncation utility
- Use the free `gemini-2.5-flash` model for job extraction and fit via a new `google_job_evaluation` profile (max_tokens 4096 so thinking tokens don't truncate structured output)

## Test plan
- [x] `APP_ENV=stage uv run pytest` (264 passed)
- [ ] Configure preferences on Settings page, save, and confirm `data/user_preferences.yaml` is written
- [ ] Evaluate a remote senior IC posting that meets defaults → expect APPLY
- [ ] Evaluate a posting that fails a required criterion (e.g. low salary or blacklisted company) → expect DO_NOT_APPLY with red required-fail badges
- [ ] Leave target role description empty → fit skipped (optional/pass); fill it in → fit LLM call runs
- [ ] Confirm evaluation runs against Gemini 2.5 Flash with a valid `GOOGLE_API_KEY`

Refs: JSA-47