### PR TITLE
build(lint): switch from black/isort to ruff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,12 +34,12 @@ jobs:
         uv sync --extra dev --frozen
       timeout-minutes: 8
 
-    - name: Lint with black
-      run: uv run black --check src tests ui
+    - name: Lint with ruff
+      run: uv run ruff check src tests ui
       timeout-minutes: 3
 
-    - name: Check imports with isort
-      run: uv run isort --check-only --profile black src tests ui
+    - name: Check formatting with ruff
+      run: uv run ruff format --check src tests ui
       timeout-minutes: 3
 
     # Temporarily disabled for prototyping - re-enable during refactoring

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,19 +9,15 @@ repos:
       - id: check-added-large-files
       - id: check-merge-conflict
 
-  # Python code formatting
-  - repo: https://github.com/psf/black
-    rev: 26.5.1
+  # Python linting, import sorting, and formatting
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.16
     hooks:
-      - id: black
-        language_version: python3.13
-
-  # Python import sorting
-  - repo: https://github.com/PyCQA/isort
-    rev: 8.0.1
-    hooks:
-      - id: isort
-        args: ["--profile", "black"]
+      # Run the linter (includes isort-style import sorting via the "I" rules)
+      - id: ruff
+        args: ["--fix"]
+      # Run the formatter
+      - id: ruff-format
 
   # Python type checking (optional - can be slow)
   # Temporarily disabled for prototyping - re-enable during refactoring

--- a/README.md
+++ b/README.md
@@ -84,8 +84,7 @@ uv run pre-commit install
 
 ### Code Quality (Automated)
 Pre-commit hooks automatically handle:
-- **Black** code formatting
-- **isort** import sorting
+- **Ruff** linting, import sorting, and code formatting
 - **mypy** type checking
 - Basic file checks
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,8 +28,7 @@ dependencies = [
 dev = [
     "pytest>=9.0.3",
     "pytest-cov>=7.1.0",
-    "black>=26.5.1",
-    "isort>=8.0.1",
+    "ruff>=0.14.0",
     "mypy>=2.1.0",
     "pre-commit>=4.6.0",
     "jupyter>=1.1.1",
@@ -56,13 +55,23 @@ allow-direct-references = true
 testpaths = ["tests"]
 python_files = ["test_*.py", "*_test.py"]
 
-[tool.black]
-line-length = 88
-target-version = ['py313']
+[tool.ruff]
+line-length = 100
+target-version = "py313"
 
-[tool.isort]
-profile = "black"
-multi_line_output = 3
+[tool.ruff.lint]
+# E/W: pycodestyle, F: pyflakes, I: isort (import sorting)
+select = ["E", "F", "I"]
+
+[tool.ruff.lint.per-file-ignores]
+# Streamlit entry point must mutate sys.path before importing the src package
+"ui/app.py" = ["E402"]
+# Import smoke tests intentionally import modules only to assert they load
+"tests/integration/test_basic_import.py" = ["F401"]
+
+[tool.ruff.format]
+# Match the previous Black formatting behavior
+quote-style = "double"
 
 [tool.mypy]
 python_version = "3.13"

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
-# Format all Python code using black and isort
+# Format and lint all Python code using ruff
 
-echo "Running Black formatter..."
-uv run black src tests ui
+echo "Running Ruff linter (with import sorting and autofix)..."
+uv run ruff check --fix src tests ui
 
-echo "Running isort import sorter..."
-uv run isort src tests ui
+echo "Running Ruff formatter..."
+uv run ruff format src tests ui
 
 echo "Checking with mypy..."
 uv run mypy src

--- a/src/agent/prompts/extraction/job_posting.py
+++ b/src/agent/prompts/extraction/job_posting.py
@@ -38,6 +38,4 @@ Job posting:
 {job_text}
 """
 
-JOB_POSTING_EXTRACTION_PROMPT = PromptTemplate.from_template(
-    JOB_POSTING_EXTRACTION_RAW_TEMPLATE
-)
+JOB_POSTING_EXTRACTION_PROMPT = PromptTemplate.from_template(JOB_POSTING_EXTRACTION_RAW_TEMPLATE)

--- a/src/agent/prompts/interview/answers.py
+++ b/src/agent/prompts/interview/answers.py
@@ -10,7 +10,9 @@ from langchain_core.prompts import PromptTemplate
 from src.agent.workflows.interview_prep.states import InterviewPrepState
 from src.models.interview import QuestionItem
 
-ANSWER_GENERATION_SYSTEM_TEMPLATE = """You are an expert interview coach. Generate personalized, compelling answers to interview questions based on the candidate's experience and the specific role.
+ANSWER_GENERATION_SYSTEM_TEMPLATE = """You are an expert interview coach. \
+Generate personalized, compelling answers to interview questions based on \
+the candidate's experience and the specific role.
 
 Guidelines:
 1. Use specific examples from the candidate's experience
@@ -38,13 +40,9 @@ Job Requirements:
 Please generate a personalized, compelling answer for this question."""
 
 
-ANSWER_GENERATION_SYSTEM_PROMPT = PromptTemplate.from_template(
-    ANSWER_GENERATION_SYSTEM_TEMPLATE
-)
+ANSWER_GENERATION_SYSTEM_PROMPT = PromptTemplate.from_template(ANSWER_GENERATION_SYSTEM_TEMPLATE)
 
-ANSWER_GENERATION_USER_PROMPT = PromptTemplate.from_template(
-    ANSWER_GENERATION_USER_TEMPLATE
-)
+ANSWER_GENERATION_USER_PROMPT = PromptTemplate.from_template(ANSWER_GENERATION_USER_TEMPLATE)
 
 
 def create_answer_system_prompt(state: InterviewPrepState) -> str:

--- a/src/agent/prompts/interview/questions.py
+++ b/src/agent/prompts/interview/questions.py
@@ -9,7 +9,9 @@ from langchain_core.prompts import PromptTemplate
 
 from src.agent.workflows.interview_prep.states import InterviewPrepState
 
-QUESTION_GENERATION_SYSTEM_TEMPLATE = """You are an expert interview preparation assistant. Your task is to generate relevant interview questions based on the job description, interview type, and company information.
+QUESTION_GENERATION_SYSTEM_TEMPLATE = """You are an expert interview preparation \
+assistant. Your task is to generate relevant interview questions based on \
+the job description, interview type, and company information.
 
 Interview Type: {interview_type}
 Interview Format: {interview_format}
@@ -17,7 +19,8 @@ Company: {company}
 Role: {role}
 Duration: {duration} minutes
 
-CRITICAL REQUIREMENT: You MUST generate EXACTLY the specified number of questions for each category:
+CRITICAL REQUIREMENT: You MUST generate EXACTLY the specified number of \
+questions for each category:
 {question_breakdown}
 
 Total questions: {total_questions}
@@ -34,7 +37,8 @@ Category: [general/behavioral/technical/culture/situational]
 Difficulty: [easy/medium/hard]
 Rationale: [Why this question is relevant]
 
-REMEMBER: You must provide exactly the requested number of questions per category. Double-check your count before submitting your response.
+REMEMBER: You must provide exactly the requested number of questions per \
+category. Double-check your count before submitting your response.
 
 ---"""
 
@@ -45,18 +49,18 @@ QUESTION_GENERATION_USER_TEMPLATE = """Job Description:
 Redacted Resume Context:
 {redacted_resume}
 
-{research_context}Please generate interview questions for this {interview_type} interview.
+{research_context}Please generate interview questions for this \
+{interview_type} interview.
 
-CRITICAL: Generate exactly {num_questions} questions in total as specified in the system prompt."""
+CRITICAL: Generate exactly {num_questions} questions in total as specified \
+in the system prompt."""
 
 
 QUESTION_GENERATION_SYSTEM_PROMPT = PromptTemplate.from_template(
     QUESTION_GENERATION_SYSTEM_TEMPLATE
 )
 
-QUESTION_GENERATION_USER_PROMPT = PromptTemplate.from_template(
-    QUESTION_GENERATION_USER_TEMPLATE
-)
+QUESTION_GENERATION_USER_PROMPT = PromptTemplate.from_template(QUESTION_GENERATION_USER_TEMPLATE)
 
 
 def create_question_system_prompt(state: InterviewPrepState) -> str:

--- a/src/agent/tools/extraction/schema_extraction_tool.py
+++ b/src/agent/tools/extraction/schema_extraction_tool.py
@@ -5,7 +5,7 @@ This module provides functions for extracting structured data from job posting t
 These functions can be used directly by LangGraph workflows and other components.
 """
 
-from typing import Any, Dict, Optional, Type
+from typing import Any, Dict, Type
 
 from langchain_core.messages import HumanMessage
 
@@ -74,14 +74,10 @@ def extract_job_posting(job_text: str) -> Dict[str, Any]:
         - location_policy: remote/hybrid/onsite/unclear
         - role_type: ic/manager/unclear
     """
-    return _extract_with_schema(
-        job_text, JobPostingExtractionSchema, JOB_POSTING_EXTRACTION_PROMPT
-    )
+    return _extract_with_schema(job_text, JobPostingExtractionSchema, JOB_POSTING_EXTRACTION_PROMPT)
 
 
-def validate_extraction_result(
-    extraction_result: Dict[str, Any], schema_name: str
-) -> bool:
+def validate_extraction_result(extraction_result: Dict[str, Any], schema_name: str) -> bool:
     """
     Validate that a job posting extraction result contains meaningful data.
 
@@ -122,7 +118,9 @@ def validate_extraction_result(
     is_valid = basic_info and additional_info
 
     logger.debug(
-        f"Job posting validation: {is_valid} (title={has_title}, company={has_company}, salary={has_salary}, policy={has_clear_policy}, role={has_clear_role})"
+        f"Job posting validation: {is_valid} (title={has_title}, "
+        f"company={has_company}, salary={has_salary}, "
+        f"policy={has_clear_policy}, role={has_clear_role})"
     )
 
     return bool(is_valid)

--- a/src/agent/tools/pii_redaction.py
+++ b/src/agent/tools/pii_redaction.py
@@ -3,7 +3,6 @@
 import logging
 import os
 import re
-from typing import Dict, List, Optional
 
 from src.models.interview import PIIRedactionResult
 
@@ -68,18 +67,12 @@ class PIIRedactionPipeline:
             self.anonymizer = AnonymizerEngine()
 
             # Test Presidio functionality
-            test_result = self.analyzer.analyze(
-                text="test email: test@example.com", language="en"
-            )
+            self.analyzer.analyze(text="test email: test@example.com", language="en")
 
             # Configure anonymization operators for phone numbers and email only
             self.anonymization_config = {
-                "EMAIL_ADDRESS": OperatorConfig(
-                    "replace", {"new_value": "[REDACTED_EMAIL]"}
-                ),
-                "PHONE_NUMBER": OperatorConfig(
-                    "replace", {"new_value": "[REDACTED_PHONE]"}
-                ),
+                "EMAIL_ADDRESS": OperatorConfig("replace", {"new_value": "[REDACTED_EMAIL]"}),
+                "PHONE_NUMBER": OperatorConfig("replace", {"new_value": "[REDACTED_PHONE]"}),
             }
 
             # Supported entity types for detection (phone numbers and email only)
@@ -132,16 +125,12 @@ class PIIRedactionPipeline:
                 end = result.end
                 original_text = resume_text[start:end]
 
-                redaction_key = self.anonymization_config[entity_type].params[
-                    "new_value"
-                ]
+                redaction_key = self.anonymization_config[entity_type].params["new_value"]
                 redactions_map[f"{redaction_key}_{i}"] = (
                     f"{entity_type}: {len(original_text)} chars, confidence: {confidence:.2f}"
                 )
 
-                redaction_log.append(
-                    f"Detected {entity_type} (confidence: {confidence:.2f})"
-                )
+                redaction_log.append(f"Detected {entity_type} (confidence: {confidence:.2f})")
 
             # Anonymize the text
             anonymized_result = self.anonymizer.anonymize(
@@ -153,9 +142,7 @@ class PIIRedactionPipeline:
             redacted_text = anonymized_result.text
 
             # Validate redaction completeness
-            complete = self._validate_redaction_complete(
-                redacted_text, analysis_results
-            )
+            complete = self._validate_redaction_complete(redacted_text, analysis_results)
 
             redaction_log.append(f"Redaction complete: {complete}")
             logger.info(f"Presidio PII redaction completed. Complete: {complete}")
@@ -189,7 +176,8 @@ class PIIRedactionPipeline:
                 matches = pattern.findall(redacted_text)
                 for i, match in enumerate(matches):
                     if isinstance(match, tuple):
-                        # For phone numbers, we need to find the full match, not just the groups
+                        # For phone numbers, we need to find the full match,
+                        # not just the groups
                         if pii_type == "PHONE":
                             full_phone_pattern = re.compile(
                                 r"(?:\+?1[-.\s]?)?\(?[0-9]{3}\)?[-.\s]?[0-9]{3}[-.\s]?[0-9]{4}"
@@ -205,9 +193,7 @@ class PIIRedactionPipeline:
                         match_str = match
 
                     redaction_token = f"[REDACTED_{pii_type}_{len(redactions_map)}]"
-                    redactions_map[redaction_token] = (
-                        f"{pii_type}: {len(match_str)} chars"
-                    )
+                    redactions_map[redaction_token] = f"{pii_type}: {len(match_str)} chars"
                     redacted_text = redacted_text.replace(match_str, redaction_token, 1)
                     redaction_log.append(f"Detected {pii_type}")
 
@@ -236,9 +222,7 @@ class PIIRedactionPipeline:
                 redaction_log=redaction_log,
             )
 
-    def _validate_redaction_complete(
-        self, redacted_text: str, analysis_results
-    ) -> bool:
+    def _validate_redaction_complete(self, redacted_text: str, analysis_results) -> bool:
         """Validate that Presidio PII redaction is complete."""
         try:
             # Re-analyze the redacted text to check if any PII remains
@@ -255,11 +239,13 @@ class PIIRedactionPipeline:
 
             if high_confidence_remaining:
                 logger.warning(
-                    f"Found {len(high_confidence_remaining)} high-confidence PII entities in redacted text"
+                    f"Found {len(high_confidence_remaining)} high-confidence "
+                    "PII entities in redacted text"
                 )
                 return False
 
-            # Additional basic pattern checks for phone numbers and email that might slip through
+            # Additional basic pattern checks for phone numbers and email that
+            # might slip through
             suspicious_patterns = [
                 (r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b", "email"),
                 (

--- a/src/agent/tools/research.py
+++ b/src/agent/tools/research.py
@@ -45,7 +45,8 @@ class ResearchWithCitations:
             search_response = self.search.invoke(search_query)
 
             # Extract results from the Tavily response
-            # According to Tavily docs, response has structure: {'results': [...], 'query': '...', etc.}
+            # According to Tavily docs, response has structure:
+            # {'results': [...], 'query': '...', etc.}
             results = search_response.get("results", [])
 
             logger.debug(f"Tavily returned {len(results)} results")
@@ -64,7 +65,8 @@ class ResearchWithCitations:
                     )
                     citations.append(citation)
                     logger.info(
-                        f"Added citation: {result.get('title', 'No title')} (accessible: {is_accessible})"
+                        f"Added citation: {result.get('title', 'No title')} "
+                        f"(accessible: {is_accessible})"
                     )
 
                 except Exception as e:
@@ -94,15 +96,11 @@ class ResearchWithCitations:
 
                 # Extract results from the Tavily response
                 results = search_response.get("results", [])
-                logger.debug(
-                    f"Topic '{topic}' - Tavily returned {len(results)} results"
-                )
+                logger.debug(f"Topic '{topic}' - Tavily returned {len(results)} results")
 
                 for result in results:
                     try:
-                        is_accessible = self._check_url_accessibility(
-                            result.get("url", "")
-                        )
+                        is_accessible = self._check_url_accessibility(result.get("url", ""))
 
                         citation = ResearchCitation(
                             url=result.get("url", ""),
@@ -114,9 +112,7 @@ class ResearchWithCitations:
                         all_citations.append(citation)
 
                     except Exception as e:
-                        logger.warning(
-                            f"Failed to process result for topic {topic}: {e}"
-                        )
+                        logger.warning(f"Failed to process result for topic {topic}: {e}")
                         continue
 
             except Exception as e:

--- a/src/agent/workflows/interview_prep/main.py
+++ b/src/agent/workflows/interview_prep/main.py
@@ -22,12 +22,10 @@ from src.llm import get_chat_model_by_profile_name, langfuse_manager
 from src.models.interview import (
     AnswerItem,
     AnswerStyle,
-    DifficultyLevel,
     InterviewGuide,
     InterviewQuestions,
     QAPair,
     QuestionCategory,
-    QuestionItem,
 )
 
 logger = logging.getLogger(__name__)
@@ -55,15 +53,9 @@ def get_interview_prep_workflow() -> StateGraph:
     workflow.add_conditional_edges(
         "validate_and_redact", _route_on_error, {"continue": "research", END: END}
     )
-    workflow.add_conditional_edges(
-        "research", _route_on_error, {"continue": "questions", END: END}
-    )
-    workflow.add_conditional_edges(
-        "questions", _route_on_error, {"continue": "answers", END: END}
-    )
-    workflow.add_conditional_edges(
-        "answers", _route_on_error, {"continue": "compile", END: END}
-    )
+    workflow.add_conditional_edges("research", _route_on_error, {"continue": "questions", END: END})
+    workflow.add_conditional_edges("questions", _route_on_error, {"continue": "answers", END: END})
+    workflow.add_conditional_edges("answers", _route_on_error, {"continue": "compile", END: END})
     workflow.add_edge("compile", END)
 
     return workflow.compile()
@@ -124,13 +116,12 @@ def research_with_citations(state: InterviewPrepState) -> Dict[str, Any]:
 
 
 def generate_questions(state: InterviewPrepState) -> Dict[str, Any]:
-    """Generate interview questions based on role and interview type using structured output."""
+    """Generate interview questions based on role and interview type using
+    structured output."""
     logger.info("Generating interview questions")
 
     try:
-        llm = get_chat_model_by_profile_name(
-            config.agents.interview_question_generation
-        )
+        llm = get_chat_model_by_profile_name(config.agents.interview_question_generation)
         structured_llm = llm.with_structured_output(InterviewQuestions)
 
         # Create system prompt for question generation
@@ -148,17 +139,13 @@ def generate_questions(state: InterviewPrepState) -> Dict[str, Any]:
         config_dict = langfuse_manager.get_config()
 
         # Generate structured questions
-        logger.info(
-            f"Generating {state.num_questions} interview questions using structured output"
-        )
+        logger.info(f"Generating {state.num_questions} interview questions using structured output")
         result = structured_llm.invoke(messages, config=config_dict)
         logger.debug(f"Result: {result}")
 
         # Extract questions from structured result
         questions = (
-            result.questions
-            if hasattr(result, "questions")
-            else result.get("questions", [])
+            result.questions if hasattr(result, "questions") else result.get("questions", [])
         )
 
         logger.info(f"Generated {len(questions)} structured interview questions")
@@ -166,7 +153,8 @@ def generate_questions(state: InterviewPrepState) -> Dict[str, Any]:
         # Validate we got the expected number of questions
         if len(questions) != state.num_questions:
             logger.warning(
-                f"Generated {len(questions)} questions but requested {state.num_questions}. "
+                f"Generated {len(questions)} questions but requested "
+                f"{state.num_questions}. "
                 "Adjusting to match request."
             )
 
@@ -175,7 +163,8 @@ def generate_questions(state: InterviewPrepState) -> Dict[str, Any]:
                 questions = questions[: state.num_questions]
                 logger.info(f"Truncated to {state.num_questions} questions")
             else:
-                # Could implement retry logic here if needed, but structured output is typically more reliable
+                # Could implement retry logic here if needed, but structured
+                # output is typically more reliable
                 logger.warning(
                     f"Only got {len(questions)} questions, proceeding with available questions"
                 )
@@ -226,15 +215,11 @@ def generate_answers(state: InterviewPrepState) -> Dict[str, Any]:
                     HumanMessage(content=user_prompt),
                 ]
 
-                logger.debug(
-                    f"Generating answer for question: {qa_pair.question.question[:50]}..."
-                )
+                logger.debug(f"Generating answer for question: {qa_pair.question.question[:50]}...")
                 response = llm.invoke(messages, config=config_dict)
 
                 # Extract answer text from response
-                answer_text = (
-                    response.content if hasattr(response, "content") else str(response)
-                )
+                answer_text = response.content if hasattr(response, "content") else str(response)
 
                 # Determine answer style based on question category
                 answer_style = _determine_answer_style(qa_pair.question.category)
@@ -253,13 +238,12 @@ def generate_answers(state: InterviewPrepState) -> Dict[str, Any]:
                 )
 
                 updated_qa_pairs.append(updated_qa_pair)
-                logger.debug(
-                    f"Generated answer for question: {qa_pair.question.question[:50]}..."
-                )
+                logger.debug(f"Generated answer for question: {qa_pair.question.question[:50]}...")
 
             except Exception as e:
                 logger.error(
-                    f"Failed to generate answer for question '{qa_pair.question.question[:50]}...': {e}"
+                    f"Failed to generate answer for question "
+                    f"'{qa_pair.question.question[:50]}...': {e}"
                 )
                 # Keep the original QA pair with empty answer
                 updated_qa_pairs.append(qa_pair)
@@ -314,9 +298,7 @@ def _get_role_specific_topics(role: str) -> List[str]:
     if "engineer" in role_lower or "developer" in role_lower:
         topics.extend(["coding interview", "technical questions", "system design"])
     elif "manager" in role_lower:
-        topics.extend(
-            ["leadership interview", "team management", "conflict resolution"]
-        )
+        topics.extend(["leadership interview", "team management", "conflict resolution"])
     elif "product" in role_lower:
         topics.extend(["product management", "user experience", "roadmap planning"])
     elif "data" in role_lower:
@@ -358,7 +340,8 @@ def _generate_preparation_tips(state: InterviewPrepState) -> List[str]:
         "Prepare thoughtful questions to ask your interviewer",
     ]
 
-    # Add interview type specific tips - use string value directly since Pydantic converts enums
+    # Add interview type specific tips - use string value directly since
+    # Pydantic converts enums
     interview_type = state.interview_details.type
     if interview_type == "technical":
         tips.extend(

--- a/src/agent/workflows/interview_prep/states.py
+++ b/src/agent/workflows/interview_prep/states.py
@@ -1,6 +1,6 @@
 """State management for interview preparation workflow."""
 
-from typing import Any, Dict, List, Optional
+from typing import List, Optional
 
 from pydantic import ConfigDict, Field
 
@@ -26,9 +26,7 @@ class InterviewPrepState(BaseDataModel):
     # Inputs
     job_description: str = Field(..., description="Job posting text")
     resume_text: str = Field(..., description="Original resume content")
-    interview_details: InterviewDetails = Field(
-        ..., description="Interview specifications"
-    )
+    interview_details: InterviewDetails = Field(..., description="Interview specifications")
 
     # CRITICAL: Error handling for workflow short-circuiting
     error: Optional[str] = Field(default=None, description="Workflow error message")

--- a/src/agent/workflows/job_evaluation/main.py
+++ b/src/agent/workflows/job_evaluation/main.py
@@ -140,9 +140,7 @@ def generate_recommendation(state: JobEvaluationState) -> Dict[str, Any]:
         }
 
     try:
-        recommendation, reasoning = generate_recommendation_from_evaluation(
-            evaluation_result
-        )
+        recommendation, reasoning = generate_recommendation_from_evaluation(evaluation_result)
 
         logger.info(f"Recommendation generated: {recommendation}")
         return {

--- a/src/config/loader.py
+++ b/src/config/loader.py
@@ -100,8 +100,7 @@ class ConfigLoader:
         if not env_str:
             valid_values = ", ".join([e.value for e in Environment])
             raise EnvironmentError(
-                f"APP_ENV environment variable is not set. "
-                f"Valid values: {valid_values}"
+                f"APP_ENV environment variable is not set. Valid values: {valid_values}"
             )
 
         try:
@@ -135,9 +134,7 @@ class ConfigLoader:
                 config_path=str(file_path),
             )
 
-    def merge_configs(
-        self, base: Dict[str, Any], override: Dict[str, Any]
-    ) -> Dict[str, Any]:
+    def merge_configs(self, base: Dict[str, Any], override: Dict[str, Any]) -> Dict[str, Any]:
         """
         Recursively merge configuration dictionaries.
 
@@ -151,11 +148,7 @@ class ConfigLoader:
         result = base.copy()
 
         for key, value in override.items():
-            if (
-                key in result
-                and isinstance(result[key], dict)
-                and isinstance(value, dict)
-            ):
+            if key in result and isinstance(result[key], dict) and isinstance(value, dict):
                 result[key] = self.merge_configs(result[key], value)
             else:
                 result[key] = value

--- a/src/config/models.py
+++ b/src/config/models.py
@@ -77,9 +77,7 @@ class LLMProfileConfig(BaseModel):
 
     provider: str = Field(..., description="LLM provider")
     model: str = Field(..., description="Model identifier")
-    temperature: float = Field(
-        default=0.0, ge=0.0, le=1.0, description="Sampling temperature"
-    )
+    temperature: float = Field(default=0.0, ge=0.0, le=1.0, description="Sampling temperature")
     max_tokens: int = Field(default=512, gt=0, description="Maximum tokens to generate")
     api_key: Optional[str] = Field(
         default=None, description="API key for the provider (from env var)"
@@ -153,7 +151,8 @@ class LLMProfileConfig(BaseModel):
             provider = info.data.get("provider", "unknown")
             raise ValueError(
                 f"API key is required for {provider} provider. "
-                f"Please set {provider.upper()}_API_KEY in your environment or .env file."
+                f"Please set {provider.upper()}_API_KEY in your environment "
+                "or .env file."
             )
 
         return v
@@ -187,9 +186,7 @@ class LangfuseConfig(BaseModel):
     """Langfuse observability configuration."""
 
     enabled: bool = Field(default=False, description="Enable Langfuse tracing")
-    host: str = Field(
-        default="https://us.cloud.langfuse.com", description="Langfuse host URL"
-    )
+    host: str = Field(default="https://us.cloud.langfuse.com", description="Langfuse host URL")
     public_key: Optional[str] = Field(
         default=None, description="Langfuse public key (from env var)"
     )
@@ -216,20 +213,15 @@ class AppConfig(BaseModel):
     general: GeneralConfig = Field(..., description="General application configuration")
     logging: LoggingConfig = Field(..., description="Logging configuration")
     agents: AgentConfig = Field(..., description="Agent configuration")
-    llm_profiles: Dict[str, LLMProfileConfig] = Field(
-        ..., description="LLM profile configurations"
-    )
-    observability: ObservabilityConfig = Field(
-        ..., description="Observability configuration"
-    )
+    llm_profiles: Dict[str, LLMProfileConfig] = Field(..., description="LLM profile configurations")
+    observability: ObservabilityConfig = Field(..., description="Observability configuration")
 
     def get_llm_profile(self, profile_name: str) -> LLMProfileConfig:
         """Get LLM profile by name with validation."""
         if profile_name not in self.llm_profiles:
             available = ", ".join(self.llm_profiles.keys())
             raise ValueError(
-                f"LLM profile '{profile_name}' not found. "
-                f"Available profiles: {available}"
+                f"LLM profile '{profile_name}' not found. Available profiles: {available}"
             )
         return self.llm_profiles[profile_name]
 

--- a/src/core/job_evaluation/evaluator.py
+++ b/src/core/job_evaluation/evaluator.py
@@ -40,9 +40,7 @@ def _result(
     }
 
 
-def _none_result(
-    config: CriterionConfig, extracted_value: Any, label: str
-) -> Dict[str, Any]:
+def _none_result(config: CriterionConfig, extracted_value: Any, label: str) -> Dict[str, Any]:
     """Build a result for a criterion whose data is missing from the posting."""
     passed = config.none_policy == NonePolicy.PASS
     decision = "pass" if passed else "fail"
@@ -77,16 +75,10 @@ def _evaluate_salary(info: Dict[str, Any], prefs: JobPreferences) -> Dict[str, A
         return _none_result(config, None, "Salary")
 
     if salary_max >= prefs.min_salary:
-        reason = (
-            f"Top-of-range salary (${salary_max:,}) meets minimum "
-            f"(${prefs.min_salary:,})"
-        )
+        reason = f"Top-of-range salary (${salary_max:,}) meets minimum (${prefs.min_salary:,})"
         return _result(True, reason, config, salary_max)
 
-    reason = (
-        f"Top-of-range salary (${salary_max:,}) is below minimum "
-        f"(${prefs.min_salary:,})"
-    )
+    reason = f"Top-of-range salary (${salary_max:,}) is below minimum (${prefs.min_salary:,})"
     return _result(False, reason, config, salary_max)
 
 
@@ -159,9 +151,7 @@ def _evaluate_travel(info: Dict[str, Any], prefs: JobPreferences) -> Dict[str, A
         return _none_result(config, value, "Travel requirement")
 
     if value == "yes":
-        return _result(
-            False, "Role requires travel but user is not willing", config, value
-        )
+        return _result(False, "Role requires travel but user is not willing", config, value)
     return _result(True, "Role does not require travel", config, value)
 
 

--- a/src/core/job_evaluation/fit_evaluator.py
+++ b/src/core/job_evaluation/fit_evaluator.py
@@ -26,16 +26,14 @@ class FitAssessment(BaseModel):
 
     verdict: Literal["good_fit", "poor_fit"] = Field(
         ...,
-        description="Whether the role's focus matches the candidate's target role/skills",
+        description=("Whether the role's focus matches the candidate's target role/skills"),
     )
     reasoning: str = Field(
         ..., description="Short explanation referring only to subject-matter alignment"
     )
 
 
-def _result(
-    passed: bool, reason: str, config_obj, extracted_value: Any
-) -> Dict[str, Any]:
+def _result(passed: bool, reason: str, config_obj, extracted_value: Any) -> Dict[str, Any]:
     """Build a criterion result dict matching the rule-based evaluator shape."""
     return {
         "pass": passed,

--- a/src/core/preferences.py
+++ b/src/core/preferences.py
@@ -48,9 +48,7 @@ def load_preferences(
             return JobPreferences()
         return JobPreferences.model_validate(data)
     except (yaml.YAMLError, ValidationError, OSError) as e:
-        logger.warning(
-            "Failed to load preferences from %s (%s); using defaults", path, e
-        )
+        logger.warning("Failed to load preferences from %s (%s); using defaults", path, e)
         return JobPreferences()
 
 

--- a/src/llm/factory.py
+++ b/src/llm/factory.py
@@ -6,7 +6,6 @@ directly, eliminating the need for a custom wrapper layer.
 """
 
 import os
-from typing import Any
 
 from langchain_core.language_models import BaseChatModel
 
@@ -29,7 +28,8 @@ def _ensure_api_key(config: LLMProfileConfig, env_var_name: str) -> str:
         api_key = os.getenv(env_var_name)
     if not api_key:
         raise LLMProviderError(
-            f"API key not found. Please set {env_var_name} in your environment or .env file. "
+            f"API key not found. Please set {env_var_name} in your "
+            f"environment or .env file. "
             f"See README.md for setup instructions."
         )
     return api_key
@@ -78,8 +78,7 @@ def get_chat_model(config: LLMProfileConfig) -> BaseChatModel:
     if constructor_name is None:
         available = ", ".join(sorted(_PROVIDER_CONSTRUCTORS.keys()))
         raise LLMProviderError(
-            f"Unsupported LLM provider: '{provider}'. "
-            f"Available providers: {available}."
+            f"Unsupported LLM provider: '{provider}'. Available providers: {available}."
         )
 
     try:
@@ -95,9 +94,7 @@ def get_chat_model(config: LLMProfileConfig) -> BaseChatModel:
             f"Make sure the required packages are installed."
         ) from e
     except Exception as e:
-        raise LLMProviderError(
-            f"Failed to create chat model for provider '{provider}': {e}"
-        ) from e
+        raise LLMProviderError(f"Failed to create chat model for provider '{provider}': {e}") from e
 
 
 def get_chat_model_by_profile_name(profile_name: str) -> BaseChatModel:

--- a/src/models/enums.py
+++ b/src/models/enums.py
@@ -41,9 +41,7 @@ class Environment(Enum):
             return full_form_mapping[env_str]
 
         valid_values = ", ".join([e.value for e in cls])
-        raise ValueError(
-            f"Invalid environment: '{env_str}'. Valid values: {valid_values}"
-        )
+        raise ValueError(f"Invalid environment: '{env_str}'. Valid values: {valid_values}")
 
 
 class JobSource(Enum):

--- a/src/models/evaluation.py
+++ b/src/models/evaluation.py
@@ -12,12 +12,8 @@ class EvaluationResult(BaseDataModel):
     """Model representing the result of evaluating a job against user preferences."""
 
     job: JobDescription = Field(..., description="The job description being evaluated.")
-    is_good_fit: bool = Field(
-        ..., description="Whether the job is considered a good fit."
-    )
-    score: float = Field(
-        ..., description="Numerical score of the evaluation (0.0 to 1.0)."
-    )
+    is_good_fit: bool = Field(..., description="Whether the job is considered a good fit.")
+    score: float = Field(..., description="Numerical score of the evaluation (0.0 to 1.0).")
     reasoning: str = Field(..., description="Reasoning behind the evaluation outcome.")
     matching_skills: List[str] = Field(
         default_factory=list, description="Skills that match the job requirements."

--- a/src/models/interview.py
+++ b/src/models/interview.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Dict, List, Optional
 
-from pydantic import Field, field_validator, model_validator
+from pydantic import Field, model_validator
 
 from src.models.base import BaseDataModel
 
@@ -79,9 +79,7 @@ class InterviewDetails(BaseDataModel):
     )
     company: Optional[str] = Field(None, description="Company name")
     role: Optional[str] = Field(None, description="Role being interviewed for")
-    duration: Optional[int] = Field(
-        None, description="Expected interview duration in minutes"
-    )
+    duration: Optional[int] = Field(None, description="Expected interview duration in minutes")
     question_mix: Dict[QuestionCategory, int] = Field(
         default_factory=dict, description="Question distribution by category"
     )
@@ -89,7 +87,8 @@ class InterviewDetails(BaseDataModel):
     @model_validator(mode="before")
     @classmethod
     def set_defaults(cls, data):
-        """Auto-populate question_mix and duration from defaults based on interview type."""
+        """Auto-populate question_mix and duration from defaults based on
+        interview type."""
         if isinstance(data, dict):
             interview_type = data.get("type")
 
@@ -197,15 +196,9 @@ class InterviewGuide(BaseDataModel):
     num_questions: int = Field(
         default=10, description="Number of questions requested for this guide"
     )
-    research_summary: Optional[str] = Field(
-        None, description="Company/role research summary"
-    )
-    qa_pairs: List[QAPair] = Field(
-        default_factory=list, description="Question and answer pairs"
-    )
+    research_summary: Optional[str] = Field(None, description="Company/role research summary")
+    qa_pairs: List[QAPair] = Field(default_factory=list, description="Question and answer pairs")
     preparation_tips: List[str] = Field(
         default_factory=list, description="General preparation advice"
     )
-    citations: List[ResearchCitation] = Field(
-        default_factory=list, description="Research sources"
-    )
+    citations: List[ResearchCitation] = Field(default_factory=list, description="Research sources")

--- a/src/models/job.py
+++ b/src/models/job.py
@@ -1,6 +1,6 @@
 """Job-related models for the job search assistant."""
 
-from typing import Any, Dict, List, Literal, Optional
+from typing import List, Literal, Optional
 
 from pydantic import ConfigDict, Field, field_validator, model_validator
 
@@ -15,12 +15,8 @@ class JobDescription(BaseDataModel):
     title: Optional[str] = Field(None, description="Job title.")
     company: Optional[str] = Field(None, description="Company name.")
     description: Optional[str] = Field(None, description="Full job description text.")
-    is_remote: Optional[bool] = Field(
-        None, description="Is the job remote? None = unknown."
-    )
-    requirements: List[str] = Field(
-        default_factory=list, description="Job requirements."
-    )
+    is_remote: Optional[bool] = Field(None, description="Is the job remote? None = unknown.")
+    requirements: List[str] = Field(default_factory=list, description="Job requirements.")
 
     raw_text: str = Field(..., description="Raw text of the job description.")
     # extracted_info: Optional[Dict[str, Any]] = Field(
@@ -44,9 +40,7 @@ class JobDescription(BaseDataModel):
     evaluation_score: Optional[float] = Field(
         None, description="Score assigned by the evaluation agent."
     )
-    evaluation_notes: Optional[str] = Field(
-        None, description="Notes from the evaluation agent."
-    )
+    evaluation_notes: Optional[str] = Field(None, description="Notes from the evaluation agent.")
 
     @field_validator("evaluation_score")
     @classmethod
@@ -102,12 +96,12 @@ class JobPostingExtractionSchema(BaseDataModel):
         examples=["ic", "manager", "unclear"],
     )
 
-    seniority_level: Literal[
-        "junior", "mid", "senior", "staff", "principal", "lead", "unclear"
-    ] = Field(
-        default="unclear",
-        description="Seniority level inferred from the job title and description",
-        examples=["senior", "staff", "principal", "unclear"],
+    seniority_level: Literal["junior", "mid", "senior", "staff", "principal", "lead", "unclear"] = (
+        Field(
+            default="unclear",
+            description="Seniority level inferred from the job title and description",
+            examples=["senior", "staff", "principal", "unclear"],
+        )
     )
 
     visa_sponsorship: Literal["yes", "no", "unclear"] = Field(
@@ -116,9 +110,7 @@ class JobPostingExtractionSchema(BaseDataModel):
         examples=["yes", "no", "unclear"],
     )
 
-    employment_type: Literal[
-        "full-time", "part-time", "contract", "internship", "unclear"
-    ] = Field(
+    employment_type: Literal["full-time", "part-time", "contract", "internship", "unclear"] = Field(
         default="unclear",
         description="Employment type of the role",
         examples=["full-time", "contract", "unclear"],
@@ -130,20 +122,20 @@ class JobPostingExtractionSchema(BaseDataModel):
         examples=["yes", "no", "unclear"],
     )
 
-    education_requirement: Literal[
-        "associate", "bachelor", "master", "phd", "none", "unclear"
-    ] = Field(
-        default="unclear",
-        description=(
-            "Minimum education the posting requires. Use 'none' when the posting "
-            "explicitly states no degree is required, 'unclear' when not mentioned."
-        ),
-        examples=["bachelor", "master", "none", "unclear"],
+    education_requirement: Literal["associate", "bachelor", "master", "phd", "none", "unclear"] = (
+        Field(
+            default="unclear",
+            description=(
+                "Minimum education the posting requires. Use 'none' when the posting "
+                "explicitly states no degree is required, 'unclear' when not mentioned."
+            ),
+            examples=["bachelor", "master", "none", "unclear"],
+        )
     )
 
     equity_offered: List[Literal["stock_options", "rsus"]] = Field(
         default_factory=list,
-        description="Equity types the posting mentions offering (empty if not mentioned)",
+        description=("Equity types the posting mentions offering (empty if not mentioned)"),
         examples=[["rsus"], ["stock_options"], []],
     )
 

--- a/src/models/resume.py
+++ b/src/models/resume.py
@@ -35,9 +35,7 @@ class Resume(BaseDataModel):
     personal_info: Dict[str, Any] = Field(
         ..., description="Personal information (e.g., name, email, phone)."
     )
-    summary: Optional[str] = Field(
-        None, description="Professional summary or objective."
-    )
+    summary: Optional[str] = Field(None, description="Professional summary or objective.")
     education: List[Education] = Field(
         default_factory=list, description="List of educational qualifications."
     )

--- a/src/models/user.py
+++ b/src/models/user.py
@@ -53,11 +53,11 @@ class JobPreferences(BaseModel):
         default_factory=lambda: ["ic", "manager"],
         description="Acceptable role types",
     )
-    acceptable_seniority: List[
-        Literal["junior", "mid", "senior", "staff", "principal", "lead"]
-    ] = Field(
-        default_factory=lambda: ["senior", "staff", "principal", "lead"],
-        description="Acceptable seniority levels",
+    acceptable_seniority: List[Literal["junior", "mid", "senior", "staff", "principal", "lead"]] = (
+        Field(
+            default_factory=lambda: ["senior", "staff", "principal", "lead"],
+            description="Acceptable seniority levels",
+        )
     )
     visa_sponsorship_required: bool = Field(
         default=False, description="Whether the user requires visa sponsorship"
@@ -93,9 +93,7 @@ class JobPreferences(BaseModel):
         default="",
         description="Free-text description of the user's target role and focus",
     )
-    key_skills: List[str] = Field(
-        default_factory=list, description="The user's key skills"
-    )
+    key_skills: List[str] = Field(default_factory=list, description="The user's key skills")
 
     # --- Per-criterion configuration ---
     # Note: every criterion defaults to none_policy=PASS so that a posting only

--- a/src/utils/text.py
+++ b/src/utils/text.py
@@ -38,7 +38,5 @@ def truncate_text(text: str, max_chars: int, label: str = "input") -> str:
     if len(text) <= max_chars:
         return text
 
-    logger.warning(
-        "Truncating %s from %d to %d characters", label, len(text), max_chars
-    )
+    logger.warning("Truncating %s from %d to %d characters", label, len(text), max_chars)
     return text[:max_chars] + _TRUNCATION_MARKER

--- a/tests/integration/agent/test_workflow_integration.py
+++ b/tests/integration/agent/test_workflow_integration.py
@@ -5,12 +5,11 @@ This module contains comprehensive integration tests that verify
 the entire workflow from job posting text to final recommendation.
 """
 
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import pytest
 
 from src.agent.workflows.job_evaluation import (
-    JobEvaluationState,
     run_job_evaluation_workflow,
 )
 from src.exceptions.llm import LLMProviderError
@@ -22,9 +21,7 @@ class TestJobEvaluationWorkflow:
     @patch("src.agent.workflows.job_evaluation.main.load_preferences")
     @patch("src.agent.workflows.job_evaluation.main.evaluate_fit")
     @patch("src.agent.tools.extraction.schema_extraction_tool._extract_with_schema")
-    @patch(
-        "src.agent.tools.extraction.schema_extraction_tool.validate_extraction_result"
-    )
+    @patch("src.agent.tools.extraction.schema_extraction_tool.validate_extraction_result")
     @patch("src.agent.workflows.job_evaluation.main.evaluate_job_against_criteria")
     def test_workflow_should_apply(
         self,
@@ -77,9 +74,7 @@ class TestJobEvaluationWorkflow:
     @patch("src.agent.workflows.job_evaluation.main.load_preferences")
     @patch("src.agent.workflows.job_evaluation.main.evaluate_fit")
     @patch("src.agent.tools.extraction.schema_extraction_tool._extract_with_schema")
-    @patch(
-        "src.agent.tools.extraction.schema_extraction_tool.validate_extraction_result"
-    )
+    @patch("src.agent.tools.extraction.schema_extraction_tool.validate_extraction_result")
     @patch("src.agent.workflows.job_evaluation.main.evaluate_job_against_criteria")
     def test_workflow_should_not_apply(
         self,
@@ -129,9 +124,7 @@ class TestJobEvaluationWorkflow:
     @patch("src.agent.workflows.job_evaluation.main.load_preferences")
     @patch("src.agent.workflows.job_evaluation.main.evaluate_fit")
     @patch("src.agent.tools.extraction.schema_extraction_tool._extract_with_schema")
-    @patch(
-        "src.agent.tools.extraction.schema_extraction_tool.validate_extraction_result"
-    )
+    @patch("src.agent.tools.extraction.schema_extraction_tool.validate_extraction_result")
     @patch("src.agent.workflows.job_evaluation.main.evaluate_job_against_criteria")
     def test_workflow_mixed_results(
         self,
@@ -224,9 +217,7 @@ class TestJobEvaluationWorkflow:
         assert final_state.evaluation_result == {}
 
     @patch("src.agent.tools.extraction.schema_extraction_tool._extract_with_schema")
-    @patch(
-        "src.agent.tools.extraction.schema_extraction_tool.validate_extraction_result"
-    )
+    @patch("src.agent.tools.extraction.schema_extraction_tool.validate_extraction_result")
     def test_workflow_extraction_failure(self, mock_validate, mock_extract_schema):
         """Test evaluation when extraction fails."""
         mock_extract_schema.side_effect = LLMProviderError("API error")
@@ -239,9 +230,7 @@ class TestJobEvaluationWorkflow:
         assert final_state.evaluation_result is None
 
     @patch("src.agent.tools.extraction.schema_extraction_tool._extract_with_schema")
-    @patch(
-        "src.agent.tools.extraction.schema_extraction_tool.validate_extraction_result"
-    )
+    @patch("src.agent.tools.extraction.schema_extraction_tool.validate_extraction_result")
     def test_workflow_invalid_extraction(self, mock_validate, mock_extract_schema):
         """Test evaluation when extraction is invalid."""
         mock_extract_schema.return_value = {"title": "", "company": ""}
@@ -254,9 +243,7 @@ class TestJobEvaluationWorkflow:
         assert final_state.extracted_info is None
         assert final_state.evaluation_result is None
 
-    @pytest.mark.parametrize(
-        "sample_job_description", ["software_engineer"], indirect=True
-    )
+    @pytest.mark.parametrize("sample_job_description", ["software_engineer"], indirect=True)
     def test_workflow_with_sample_data(self, sample_job_description):
         """Test evaluation with real sample job description."""
         final_state = run_job_evaluation_workflow(sample_job_description)

--- a/tests/unit/agent/test_job_evaluation_nodes.py
+++ b/tests/unit/agent/test_job_evaluation_nodes.py
@@ -27,7 +27,8 @@ class TestValidateInput:
 
 class TestExtractUsesBoundedText:
     def test_extract_does_not_re_truncate(self, monkeypatch):
-        """extract_job_info should pass state text straight through (already bounded)."""
+        """extract_job_info should pass state text straight through
+        (already bounded)."""
         captured = {}
 
         def fake_extract(text):

--- a/tests/unit/agent/test_schema_extraction_tools.py
+++ b/tests/unit/agent/test_schema_extraction_tools.py
@@ -32,9 +32,7 @@ class TestExtractJobPosting:
         }
         mock_extract_with_schema.return_value = expected_result
 
-        result = extract_job_posting(
-            "Software Engineer at TechCorp, remote, $140k-$170k"
-        )
+        result = extract_job_posting("Software Engineer at TechCorp, remote, $140k-$170k")
 
         assert result == expected_result
         mock_extract_with_schema.assert_called_once()

--- a/tests/unit/config/test_system.py
+++ b/tests/unit/config/test_system.py
@@ -6,16 +6,13 @@ ConfigManager, and the singleton pattern.
 """
 
 import os
-import tempfile
-from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
-from src.config import ConfigLoader, ConfigManager, config
+from src.config import ConfigLoader, ConfigManager
 from src.config.models import AppConfig
 from src.exceptions.config import (
-    ConfigError,
     ConfigFileError,
     ConfigValidationError,
     EnvironmentError,
@@ -98,9 +95,7 @@ level = "DEBUG"
 
         with patch.dict(os.environ, {}, clear=True):
             loader = ConfigLoader(config_dir=tmp_path)
-            with pytest.raises(
-                EnvironmentError, match="APP_ENV environment variable is not set"
-            ):
+            with pytest.raises(EnvironmentError, match="APP_ENV environment variable is not set"):
                 loader.get_environment()
 
     def test_invalid_app_env_raises_error(self, tmp_path):
@@ -125,9 +120,7 @@ level = "DEBUG"
 
         with patch.dict(os.environ, {"APP_ENV": "dev"}):
             loader = ConfigLoader(config_dir=tmp_path)
-            with pytest.raises(
-                ConfigFileError, match="Environment configuration file not found"
-            ):
+            with pytest.raises(ConfigFileError, match="Environment configuration file not found"):
                 loader.load_raw_config()
 
     def test_secrets_loading(self, tmp_path):
@@ -174,17 +167,10 @@ enabled = true
             raw_config = loader.load_raw_config()
 
             assert (
-                raw_config["llm_profiles"]["anthropic_profile"]["api_key"]
-                == "test_anthropic_key"
+                raw_config["llm_profiles"]["anthropic_profile"]["api_key"] == "test_anthropic_key"
             )
-            assert (
-                raw_config["observability"]["langfuse"]["public_key"]
-                == "test_public_key"
-            )
-            assert (
-                raw_config["observability"]["langfuse"]["secret_key"]
-                == "test_secret_key"
-            )
+            assert raw_config["observability"]["langfuse"]["public_key"] == "test_public_key"
+            assert raw_config["observability"]["langfuse"]["secret_key"] == "test_secret_key"
 
     def test_config_merging(self, tmp_path):
         """Test that configurations are properly merged."""
@@ -310,9 +296,7 @@ enabled = false
 
             # Different parameters should create different instances
             manager3 = ConfigManager()  # No config_dir parameter
-            assert (
-                manager1 is not manager3
-            )  # Different instances due to different params
+            assert manager1 is not manager3  # Different instances due to different params
 
     def test_reload_functionality(self, tmp_path):
         """Test that configuration can be reloaded."""
@@ -583,15 +567,9 @@ temperature = 0.0
             assert settings.general.name == "integration-test"
             assert settings.general.debug is True  # Overridden by dev.toml
             assert settings.logging.level == "DEBUG"  # Overridden by dev.toml
-            assert (
-                settings.llm_profiles["claude_profile"].temperature == 0.0
-            )  # Overridden
-            assert (
-                settings.llm_profiles["claude_profile"].api_key == "test-key"
-            )  # From env
-            assert (
-                settings.observability.langfuse.public_key == "test-public"
-            )  # From env
+            assert settings.llm_profiles["claude_profile"].temperature == 0.0  # Overridden
+            assert settings.llm_profiles["claude_profile"].api_key == "test-key"  # From env
+            assert settings.observability.langfuse.public_key == "test-public"  # From env
 
             # Test model methods
             profile = settings.get_llm_profile("claude_profile")

--- a/tests/unit/exceptions/test_exceptions.py
+++ b/tests/unit/exceptions/test_exceptions.py
@@ -107,9 +107,11 @@ class TestConfigError:
         config_path = "/path/to/config.toml"
         details = {"line": 10, "column": 5}
 
-        # ConfigError inherits from JobSearchAssistantError, so it should support details
+        # ConfigError inherits from JobSearchAssistantError, so it should
+        # support details
         error = ConfigError(message, config_path)
-        error.details = details  # Set details manually since ConfigError doesn't take it in __init__
+        # Set details manually since ConfigError doesn't take it in __init__
+        error.details = details
 
         assert error.message == message
         assert error.config_path == config_path
@@ -170,7 +172,8 @@ class TestConfigError:
             raise EnvironmentError("env error")
 
     def test_config_error_subclasses_can_be_caught_as_base_error(self):
-        """Test that config error subclasses can be caught as JobSearchAssistantError."""
+        """Test that config error subclasses can be caught as
+        JobSearchAssistantError."""
         # Test ConfigError itself
         with pytest.raises(JobSearchAssistantError):
             raise ConfigError("config error")

--- a/tests/unit/integration/test_api_key_validation.py
+++ b/tests/unit/integration/test_api_key_validation.py
@@ -45,7 +45,8 @@ class TestAPIKeyValidation:
         assert model is not None
 
     def test_different_providers_require_different_api_keys(self):
-        """Test that different providers validate their specific API key environment variables."""
+        """Test that different providers validate their specific API key
+        environment variables."""
         anthropic_config = LLMProfileConfig(
             provider="anthropic",
             model="claude-haiku-4-5",

--- a/tests/unit/integration/test_environment_check.py
+++ b/tests/unit/integration/test_environment_check.py
@@ -4,8 +4,6 @@ Tests for environment check component functionality
 
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from ui.components.environment_check import check_environment_setup
 
 

--- a/tests/unit/llm/observability/test_langfuse.py
+++ b/tests/unit/llm/observability/test_langfuse.py
@@ -5,8 +5,6 @@ Unit tests for Langfuse manager functionality.
 import os
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from src.llm import LangfuseManager, langfuse_manager
 
 
@@ -113,7 +111,8 @@ class TestLangfuseManager:
 
     @patch("src.llm.langfuse._workflow_context")
     def test_get_config_force_tracing_in_workflow_context(self, mock_context):
-        """Test get_config with force_tracing=True includes tracing even in workflow context."""
+        """Test get_config with force_tracing=True includes tracing even in
+        workflow context."""
         mock_context.get.return_value = True
         mock_handler = MagicMock()
 

--- a/tests/unit/llm/test_factory.py
+++ b/tests/unit/llm/test_factory.py
@@ -42,9 +42,7 @@ class TestGetChatModel:
         mock_model = MagicMock()
         mock_create.return_value = mock_model
 
-        config = LLMProfileConfig(
-            provider="google", model="gemini-2.5-flash", api_key="test-key"
-        )
+        config = LLMProfileConfig(provider="google", model="gemini-2.5-flash", api_key="test-key")
 
         result = get_chat_model(config)
 

--- a/tests/unit/llm/test_langfuse_config.py
+++ b/tests/unit/llm/test_langfuse_config.py
@@ -5,7 +5,7 @@ Unit tests for Langfuse configuration via centralized configuration.
 import os
 from unittest.mock import patch
 
-from src.config import ConfigManager, config
+from src.config import config
 
 
 class TestLangfuseConfig:
@@ -27,11 +27,7 @@ class TestLangfuseConfig:
         langfuse_config = config.observability.langfuse
 
         # With mocked keys, should be valid if enabled
-        if (
-            langfuse_config.enabled
-            and langfuse_config.public_key
-            and langfuse_config.secret_key
-        ):
+        if langfuse_config.enabled and langfuse_config.public_key and langfuse_config.secret_key:
             assert langfuse_config.is_valid() is True
         else:
             # If disabled or missing keys, should be invalid
@@ -48,8 +44,10 @@ class TestLangfuseConfig:
             os.environ,
             {
                 "APP_ENV": "dev",
-                "ANTHROPIC_API_KEY": "test-anthropic-key",  # Required for dev environment
-                "GOOGLE_API_KEY": "test-google-key",  # Required for google_extraction profile
+                # Required for dev environment
+                "ANTHROPIC_API_KEY": "test-anthropic-key",
+                # Required for google_extraction profile
+                "GOOGLE_API_KEY": "test-google-key",
                 "LANGFUSE_PUBLIC_KEY": "test_public_key",
                 "LANGFUSE_SECRET_KEY": "test_secret_key",
             },
@@ -67,8 +65,10 @@ class TestLangfuseConfig:
             os.environ,
             {
                 "APP_ENV": "dev",
-                "ANTHROPIC_API_KEY": "test-anthropic-key",  # Required for dev environment
-                "GOOGLE_API_KEY": "test-google-key",  # Required for google_extraction profile
+                # Required for dev environment
+                "ANTHROPIC_API_KEY": "test-anthropic-key",
+                # Required for google_extraction profile
+                "GOOGLE_API_KEY": "test-google-key",
             },
         ):
             test_config = config.reload()
@@ -92,8 +92,10 @@ class TestLangfuseConfig:
             os.environ,
             {
                 "APP_ENV": "prod",
-                "ANTHROPIC_API_KEY": "test-anthropic-key",  # Required for prod environment
-                "GOOGLE_API_KEY": "test-google-key",  # Required for google_extraction profile
+                # Required for prod environment
+                "ANTHROPIC_API_KEY": "test-anthropic-key",
+                # Required for google_extraction profile
+                "GOOGLE_API_KEY": "test-google-key",
             },
         ):
             test_config = config.reload()

--- a/tests/unit/models/test_models.py
+++ b/tests/unit/models/test_models.py
@@ -1,7 +1,5 @@
 """Unit tests for data models."""
 
-from datetime import datetime
-
 import pytest
 from pydantic import ValidationError
 
@@ -311,9 +309,7 @@ class TestResumeModel:
             "address": "123 Main St, City, State 12345",
         }
 
-        education = [
-            Education(institution="MIT", degree="BS", field_of_study="Computer Science")
-        ]
+        education = [Education(institution="MIT", degree="BS", field_of_study="Computer Science")]
 
         experience = [
             Experience(
@@ -466,9 +462,7 @@ class TestJobDescriptionModel:
         assert job.url is None
         assert job.date_posted is None
         assert job.date_scraped is None
-        assert (
-            job.status == JobStatus.PENDING_EVALUATION
-        )  # Default values remain as enum objects
+        assert job.status == JobStatus.PENDING_EVALUATION  # Default values remain as enum objects
         assert job.evaluation_score is None
         assert job.evaluation_notes is None
 
@@ -525,22 +519,16 @@ class TestJobDescriptionModel:
         assert job3.evaluation_score == 0.5
 
         # Invalid scores
-        with pytest.raises(
-            ValidationError, match="Evaluation score must be between 0 and 1"
-        ):
+        with pytest.raises(ValidationError, match="Evaluation score must be between 0 and 1"):
             JobDescription(raw_text="test", evaluation_score=-0.1)
 
-        with pytest.raises(
-            ValidationError, match="Evaluation score must be between 0 and 1"
-        ):
+        with pytest.raises(ValidationError, match="Evaluation score must be between 0 and 1"):
             JobDescription(raw_text="test", evaluation_score=1.1)
 
     def test_job_description_default_status(self):
         """Test JobDescription default status."""
         job = JobDescription(raw_text="test")
-        assert (
-            job.status == JobStatus.PENDING_EVALUATION
-        )  # Default values remain as enum objects
+        assert job.status == JobStatus.PENDING_EVALUATION  # Default values remain as enum objects
 
     def test_job_description_serialization(self):
         """Test JobDescription model serialization."""
@@ -620,14 +608,10 @@ class TestEvaluationResultModel:
         job = JobDescription(raw_text="test")
 
         # Valid scores
-        result1 = EvaluationResult(
-            job=job, is_good_fit=True, score=0.0, reasoning="test"
-        )
+        result1 = EvaluationResult(job=job, is_good_fit=True, score=0.0, reasoning="test")
         assert result1.score == 0.0
 
-        result2 = EvaluationResult(
-            job=job, is_good_fit=True, score=1.0, reasoning="test"
-        )
+        result2 = EvaluationResult(job=job, is_good_fit=True, score=1.0, reasoning="test")
         assert result2.score == 1.0
 
         # Invalid scores
@@ -731,8 +715,9 @@ class TestModelInteroperability:
         """Test that validation errors cascade through nested models."""
         # Create an invalid job (score out of range)
         with pytest.raises(ValidationError):
-            invalid_job = JobDescription(
-                raw_text="test", evaluation_score=1.5  # Invalid score
+            JobDescription(
+                raw_text="test",
+                evaluation_score=1.5,  # Invalid score
             )
 
         # Create a valid job

--- a/tests/unit/utils/test_logging.py
+++ b/tests/unit/utils/test_logging.py
@@ -5,8 +5,6 @@ import sys
 from io import StringIO
 from unittest.mock import Mock, patch
 
-import pytest
-
 from src.utils.logging import get_app_logger, get_logger, setup_logging
 
 
@@ -171,9 +169,6 @@ class TestSetupLogging:
         formatter = handler.formatter
 
         # Test that datetime format is applied
-        import datetime
-
-        test_time = datetime.datetime(2024, 1, 15, 14, 30, 45)
         formatted_time = formatter.formatTime(
             logging.LogRecord(
                 name="test",
@@ -287,9 +282,7 @@ class TestLoggingIntegration:
         # Create a custom handler to capture output
         captured_output = StringIO()
         test_handler = logging.StreamHandler(captured_output)
-        test_handler.setFormatter(
-            logging.Formatter("%(name)s [%(levelname)s] %(message)s")
-        )
+        test_handler.setFormatter(logging.Formatter("%(name)s [%(levelname)s] %(message)s"))
 
         # Setup logging with DEBUG level
         setup_logging(level="DEBUG")
@@ -349,9 +342,7 @@ class TestLoggingIntegration:
         # Create a custom handler to capture output
         captured_output = StringIO()
         test_handler = logging.StreamHandler(captured_output)
-        test_handler.setFormatter(
-            logging.Formatter("%(name)s [%(levelname)s] %(message)s")
-        )
+        test_handler.setFormatter(logging.Formatter("%(name)s [%(levelname)s] %(message)s"))
 
         setup_logging(level="ERROR")
 

--- a/tests/unit/utils/test_singleton.py
+++ b/tests/unit/utils/test_singleton.py
@@ -7,7 +7,6 @@ including edge cases and thread safety.
 
 import threading
 import time
-from unittest.mock import patch
 
 import pytest
 
@@ -185,9 +184,7 @@ class TestSingletonDecorator:
         original_time = instance1.created_at
 
         # First reload with parameters to establish the _singleton_key
-        instance2 = instance1.reload_singleton(
-            value="first_reload", other="test_reload"
-        )
+        instance2 = instance1.reload_singleton(value="first_reload", other="test_reload")
 
         time.sleep(0.01)
 
@@ -274,7 +271,8 @@ class TestSingletonDecorator:
                 # The _singleton_reload parameter should not be passed to __init__
                 # This test ensures it's properly filtered out
 
-        # This should work without the _singleton_reload parameter being passed to __init__
+        # This should work without the _singleton_reload parameter being
+        # passed to __init__
         instance1 = TestClass(value="test")
         instance2 = instance1.reload_singleton(value="reloaded")
 
@@ -353,8 +351,10 @@ class TestSingletonEdgeCases:
             def __init__(self, data):
                 self.data = data
 
-        # Lists and dicts are unhashable and should cause an error when used as dict keys
-        # The singleton decorator should raise TypeError when trying to use unhashable types
+        # Lists and dicts are unhashable and should cause an error when used
+        # as dict keys
+        # The singleton decorator should raise TypeError when trying to use
+        # unhashable types
         with pytest.raises(TypeError, match="unhashable type"):
             TestClass([1, 2, 3])
 
@@ -362,7 +362,8 @@ class TestSingletonEdgeCases:
             TestClass({"key": "value"})
 
     def test_singleton_memory_behavior(self):
-        """Test that singleton doesn't cause memory leaks by holding too many instances."""
+        """Test that singleton doesn't cause memory leaks by holding too many
+        instances."""
 
         @singleton
         class TestClass:

--- a/ui/app.py
+++ b/ui/app.py
@@ -2,7 +2,6 @@
 Main Streamlit application for Job Search Assistant
 """
 
-import os
 import sys
 from pathlib import Path
 

--- a/ui/pages/interview_prep.py
+++ b/ui/pages/interview_prep.py
@@ -7,7 +7,6 @@ import streamlit as st
 
 from src.agent.tools.pii_redaction import pii_pipeline
 from src.agent.workflows.interview_prep.main import (
-    get_interview_prep_workflow,
     run_interview_prep_workflow,
 )
 from src.agent.workflows.interview_prep.states import InterviewPrepState
@@ -136,19 +135,22 @@ def render_interview_prep_page():
         from src.agent.tools.pii_redaction import pii_pipeline
 
         if pii_pipeline.presidio_available is None:
-            pii_method = (
-                "Will be determined automatically (Presidio preferred, regex fallback)"
-            )
+            pii_method = "Will be determined automatically (Presidio preferred, regex fallback)"
         elif pii_pipeline.presidio_available:
             pii_method = "Microsoft Presidio (enterprise-grade NLP-based detection)"
         else:
             pii_method = "Regex patterns (basic pattern matching)"
         st.info(
-            f"🔒 **Privacy Notice**: Your resume will be automatically redacted to remove personal information (names, emails, phone numbers) before being processed by AI models.\n\n**PII Detection Method**: {pii_method}"
+            f"🔒 **Privacy Notice**: Your resume will be automatically "
+            f"redacted to remove personal information (names, emails, phone "
+            f"numbers) before being processed by AI models.\n\n"
+            f"**PII Detection Method**: {pii_method}"
         )
-    except:
+    except Exception:
         st.info(
-            "🔒 **Privacy Notice**: Your resume will be automatically redacted to remove personal information (names, emails, phone numbers) before being processed by AI models."
+            "🔒 **Privacy Notice**: Your resume will be automatically redacted "
+            "to remove personal information (names, emails, phone numbers) "
+            "before being processed by AI models."
         )
 
     # Generate button
@@ -248,7 +250,6 @@ def generate_interview_guide(
 
 def process_interview_workflow(initial_state: InterviewPrepState):
     """Process the interview preparation workflow."""
-    import threading
     import time
     from concurrent.futures import Future, ThreadPoolExecutor
 
@@ -291,9 +292,7 @@ def process_interview_workflow(initial_state: InterviewPrepState):
                 progress_bar.progress(progress_value)
 
                 # Wait a bit before next update, but check if workflow is done
-                for _ in range(
-                    10
-                ):  # Check every 0.5 seconds for 5 seconds total per step
+                for _ in range(10):  # Check every 0.5 seconds for 5 seconds total per step
                     if workflow_future.done():
                         break
                     time.sleep(0.5)
@@ -379,9 +378,7 @@ def display_interview_guide():
             ]
         if difficulty_filter != "All":
             filtered_pairs = [
-                qa
-                for qa in filtered_pairs
-                if qa.question.difficulty == difficulty_filter
+                qa for qa in filtered_pairs if qa.question.difficulty == difficulty_filter
             ]
 
         # Display questions
@@ -393,7 +390,8 @@ def display_interview_guide():
                 with col2:
                     difficulty_colors = {"easy": "🟢", "medium": "🟡", "hard": "🔴"}
                     st.write(
-                        f"{difficulty_colors.get(qa_pair.question.difficulty, '⚪')} {qa_pair.question.difficulty.title()}"
+                        f"{difficulty_colors.get(qa_pair.question.difficulty, '⚪')} "
+                        f"{qa_pair.question.difficulty.title()}"
                     )
                 with col3:
                     st.write(f"Style: {qa_pair.answer.style.title()}")
@@ -412,16 +410,12 @@ def display_interview_guide():
 
     # Citations
     if guide.citations:
-        with st.expander(
-            f"📚 Research Sources ({len(guide.citations)} sources)", expanded=False
-        ):
+        with st.expander(f"📚 Research Sources ({len(guide.citations)} sources)", expanded=False):
             for citation in guide.citations:
                 accessibility_indicator = "✅" if citation.is_accessible else "❌"
                 st.markdown(f"{accessibility_indicator} **{citation.title}**")
                 st.markdown(f"🔗 [{citation.url}]({citation.url})")
-                st.markdown(
-                    f"📅 Accessed: {citation.accessed_at.strftime('%Y-%m-%d %H:%M')}"
-                )
+                st.markdown(f"📅 Accessed: {citation.accessed_at.strftime('%Y-%m-%d %H:%M')}")
                 if citation.content_snippet:
                     st.markdown(f"📄 *{citation.content_snippet}*")
                 st.markdown("---")
@@ -490,9 +484,7 @@ def format_guide_as_text(guide) -> str:
         for citation in guide.citations:
             text_parts.append(f"• {citation.title}")
             text_parts.append(f"  {citation.url}")
-            text_parts.append(
-                f"  Accessed: {citation.accessed_at.strftime('%Y-%m-%d %H:%M')}"
-            )
+            text_parts.append(f"  Accessed: {citation.accessed_at.strftime('%Y-%m-%d %H:%M')}")
             text_parts.append("")
 
     return "\n".join(text_parts)
@@ -517,11 +509,7 @@ def display_guide_stats(guide):
         accessible_sources = sum(1 for c in guide.citations if c.is_accessible)
         st.metric(
             "Accessible Sources",
-            (
-                f"{accessible_sources}/{len(guide.citations)}"
-                if guide.citations
-                else "0/0"
-            ),
+            (f"{accessible_sources}/{len(guide.citations)}" if guide.citations else "0/0"),
         )
 
     if guide.qa_pairs:

--- a/ui/pages/job_evaluation.py
+++ b/ui/pages/job_evaluation.py
@@ -5,7 +5,6 @@ Job Evaluation page for analyzing job postings
 import streamlit as st
 
 from src.agent.workflows.job_evaluation import (
-    JobEvaluationState,
     run_job_evaluation_workflow,
 )
 from ui.components.environment_check import check_environment_setup
@@ -37,9 +36,7 @@ def render_job_evaluation_page():
     # Evaluation button and results
     col1, col2, col3 = st.columns([1, 2, 1])
     with col2:
-        evaluate_btn = st.button(
-            "🚀 Evaluate Job", type="primary", use_container_width=True
-        )
+        evaluate_btn = st.button("🚀 Evaluate Job", type="primary", use_container_width=True)
 
     if evaluate_btn:
         if not job_description.strip():
@@ -47,15 +44,10 @@ def render_job_evaluation_page():
         else:
             env_ok, _ = check_environment_setup()
             if not env_ok:
-                st.error(
-                    "⚠️ Please configure your API keys first "
-                    "(see instructions above)."
-                )
+                st.error("⚠️ Please configure your API keys first (see instructions above).")
             else:
                 # Show loading state
-                with st.spinner(
-                    "🔍 Analyzing job posting... This may take several seconds."
-                ):
+                with st.spinner("🔍 Analyzing job posting... This may take several seconds."):
                     try:
                         # Run the job evaluation workflow
                         final_state = run_job_evaluation_workflow(job_description)

--- a/ui/pages/settings.py
+++ b/ui/pages/settings.py
@@ -68,9 +68,7 @@ def _multiselect(label, options_map, current, help_text=None, key=None):
     labels = list(options_map.values())
     label_to_value = {v: k for k, v in options_map.items()}
     default_labels = [options_map[v] for v in current if v in options_map]
-    selected = st.multiselect(
-        label, labels, default=default_labels, help=help_text, key=key
-    )
+    selected = st.multiselect(label, labels, default=default_labels, help=help_text, key=key)
     return [label_to_value[s] for s in selected]
 
 
@@ -219,17 +217,13 @@ def render_settings_page():
         help="Postings from these companies will fail the blacklist check.",
         key="pref_blacklist",
     )
-    company_blacklist = [
-        line.strip() for line in blacklist_text.splitlines() if line.strip()
-    ]
+    company_blacklist = [line.strip() for line in blacklist_text.splitlines() if line.strip()]
 
     st.subheader("🎯 Fit")
     target_role_description = st.text_area(
         "Target role description",
         value=prefs.target_role_description,
-        placeholder=(
-            "e.g. AI/ML Engineer focused on LLMs, RAG, and production ML systems"
-        ),
+        placeholder=("e.g. AI/ML Engineer focused on LLMs, RAG, and production ML systems"),
         help="Used by the AI fit assessment. Leave empty to skip fit evaluation.",
         key="pref_target_role",
     )
@@ -264,9 +258,7 @@ def render_settings_page():
                     f"{label} — if not in posting",
                     ["pass", "fail"],
                     index=["pass", "fail"].index(current.none_policy.value),
-                    format_func=lambda v: (
-                        "Count as pass" if v == "pass" else "Count as fail"
-                    ),
+                    format_func=lambda v: "Count as pass" if v == "pass" else "Count as fail",
                     key=f"{attr}_none",
                 )
             criteria_configs[attr] = CriterionConfig(mode=mode, none_policy=none_policy)

--- a/uv.lock
+++ b/uv.lock
@@ -331,33 +331,6 @@ wheels = [
 ]
 
 [[package]]
-name = "black"
-version = "26.5.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "mypy-extensions" },
-    { name = "packaging" },
-    { name = "pathspec" },
-    { name = "platformdirs" },
-    { name = "pytokens" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c0/37/5628dd55bf2b34257fc7603f0fe97c40e3aaf24265f416a9c85c95ca1436/black-26.5.1.tar.gz", hash = "sha256:dd321f668053961824bcc1be1cc1df748b2d7e4fa28086b08331e577b0100a73", size = 679439, upload-time = "2026-05-18T16:53:36.107Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/5c/c384363980e11e25ca6b93205949bb331fbf35f4e0dbec376dfa6326cec8/black-26.5.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:2b36cf2ddf5566e205f6535f782a62194a184d33e175b64ae8c40b1737522be3", size = 2009020, upload-time = "2026-05-18T17:05:28.132Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/df/9f31c5e0babbfed77d505fc5d120beb98b21b33feaeded3924ea941fe360/black-26.5.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1f7ea64ebfa01b50f693508fc39f875e264446d3b097088f84f203b9d09618a0", size = 1813335, upload-time = "2026-05-18T17:05:31.266Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/24/8e7b9a2fa61b0afd82209efe937557d180a1fa055bd7f6161eb9defc3719/black-26.5.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ecb3e624844c798144e9bd986954e0adc81d8911a1f30f375e1252fe26e8c294", size = 1881614, upload-time = "2026-05-18T17:05:32.718Z" },
-    { url = "https://files.pythonhosted.org/packages/49/ad/b4e0d9365ba8ac34f6bbab62a4b1b2dd5d618fac3fa1b8db968c844201b5/black-26.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:e1a26503279b6b310669fb0b219c39e4820b77e8189fe80f522bb511f247db0a", size = 1488925, upload-time = "2026-05-18T17:05:34.259Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/4b/652b859bf5df88a751c30451b09338f7fd26a77d1271c666992f836b7711/black-26.5.1-cp313-cp313-win_arm64.whl", hash = "sha256:5c34b25da232ead53a6f335b76dbea124f4d152ad568b9080d6f944bc2b34b52", size = 1289883, upload-time = "2026-05-18T17:05:36.019Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/16/a8da8eb208c51c7f4ce74609a45d0dcc6d8a2141e45e81ee5289d1bb0d59/black-26.5.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:e88976690a64b0af98312ca958415849cb42423423c5f2ee74af4b49a97a2168", size = 2004800, upload-time = "2026-05-18T17:05:38.182Z" },
-    { url = "https://files.pythonhosted.org/packages/11/8a/a479296a19e383b70a725882a6cf3d786540601ff03cabbaaf1cce864c5a/black-26.5.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:32d5ea7f6c8bdfa6e648326ebca1f02b0764e2a029edc6f8dce2627e19d468c3", size = 1815576, upload-time = "2026-05-18T17:05:40.309Z" },
-    { url = "https://files.pythonhosted.org/packages/81/6b/cfaf3d39f25132c156a068f6b805576c9103a84086019507c70e1911ee7d/black-26.5.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ea8d16dc41655aa113cd64665e7219446cd7e4ff2248d7178eaa905190c86b18", size = 1877927, upload-time = "2026-05-18T17:05:42.463Z" },
-    { url = "https://files.pythonhosted.org/packages/66/76/302e313964bcff7e28df329d39f84f5270095730d85ff0acc260610a0d82/black-26.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:577f21094ea469ef92ec1adaf2c9441a226d2144d01a5be2fa823cecf6543e50", size = 1511860, upload-time = "2026-05-18T17:05:43.943Z" },
-    { url = "https://files.pythonhosted.org/packages/27/4e/a3827e35e0e567f9f9ee59e2a0ab979267dca98718f25547ca8c6733afd4/black-26.5.1-cp314-cp314-win_arm64.whl", hash = "sha256:ed1a20af114c301a0269bf01163d51dbef72737fd65f850001e7cbe7f3c7abae", size = 1316632, upload-time = "2026-05-18T17:05:45.521Z" },
-    { url = "https://files.pythonhosted.org/packages/94/51/f975cae76d44274cc2868dc9040ac5d58d464784610234455b4e7b19c6ef/black-26.5.1-py3-none-any.whl", hash = "sha256:4ed7f7da04046d2e488437170797d3b4a4ad83906683bcb7dfc68b673bbce5e2", size = 213693, upload-time = "2026-05-18T16:53:33.964Z" },
-]
-
-[[package]]
 name = "bleach"
 version = "6.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1204,15 +1177,6 @@ wheels = [
 ]
 
 [[package]]
-name = "isort"
-version = "8.0.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ef/7c/ec4ab396d31b3b395e2e999c8f46dec78c5e29209fac49d1f4dace04041d/isort-8.0.1.tar.gz", hash = "sha256:171ac4ff559cdc060bcfff550bc8404a486fee0caab245679c2abe7cb253c78d", size = 769592, upload-time = "2026-02-28T10:08:20.685Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3e/95/c7c34aa53c16353c56d0b802fba48d5f5caa2cdee7958acbcb795c830416/isort-8.0.1-py3-none-any.whl", hash = "sha256:28b89bc70f751b559aeca209e6120393d43fbe2490de0559662be7a9787e3d75", size = 89733, upload-time = "2026-02-28T10:08:19.466Z" },
-]
-
-[[package]]
 name = "itsdangerous"
 version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1322,14 +1286,13 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
-    { name = "black" },
     { name = "ipykernel" },
-    { name = "isort" },
     { name = "jupyter" },
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "ruff" },
 ]
 presidio = [
     { name = "en-core-web-sm" },
@@ -1337,11 +1300,9 @@ presidio = [
 
 [package.metadata]
 requires-dist = [
-    { name = "black", marker = "extra == 'dev'", specifier = ">=26.5.1" },
     { name = "en-core-web-sm", marker = "extra == 'presidio'", url = "https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "ipykernel", marker = "extra == 'dev'", specifier = ">=7.2.0" },
-    { name = "isort", marker = "extra == 'dev'", specifier = ">=8.0.1" },
     { name = "jupyter", marker = "extra == 'dev'", specifier = ">=1.1.1" },
     { name = "langchain", specifier = ">=1.3.1" },
     { name = "langchain-anthropic", specifier = ">=1.4.3" },
@@ -1359,6 +1320,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7.1.0" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "pyyaml", specifier = ">=6.0.3" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.14.0" },
     { name = "streamlit", specifier = ">=1.57.0" },
 ]
 provides-extras = ["dev", "presidio"]
@@ -3100,30 +3062,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pytokens"
-version = "0.4.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b6/34/b4e015b99031667a7b960f888889c5bd34ef585c85e1cb56a594b92836ac/pytokens-0.4.1.tar.gz", hash = "sha256:292052fe80923aae2260c073f822ceba21f3872ced9a68bb7953b348e561179a", size = 23015, upload-time = "2026-01-30T01:03:45.924Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/dc/08b1a080372afda3cceb4f3c0a7ba2bde9d6a5241f1edb02a22a019ee147/pytokens-0.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8bdb9d0ce90cbf99c525e75a2fa415144fd570a1ba987380190e8b786bc6ef9b", size = 160720, upload-time = "2026-01-30T01:03:13.843Z" },
-    { url = "https://files.pythonhosted.org/packages/64/0c/41ea22205da480837a700e395507e6a24425151dfb7ead73343d6e2d7ffe/pytokens-0.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5502408cab1cb18e128570f8d598981c68a50d0cbd7c61312a90507cd3a1276f", size = 254204, upload-time = "2026-01-30T01:03:14.886Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/d2/afe5c7f8607018beb99971489dbb846508f1b8f351fcefc225fcf4b2adc0/pytokens-0.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29d1d8fb1030af4d231789959f21821ab6325e463f0503a61d204343c9b355d1", size = 268423, upload-time = "2026-01-30T01:03:15.936Z" },
-    { url = "https://files.pythonhosted.org/packages/68/d4/00ffdbd370410c04e9591da9220a68dc1693ef7499173eb3e30d06e05ed1/pytokens-0.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:970b08dd6b86058b6dc07efe9e98414f5102974716232d10f32ff39701e841c4", size = 266859, upload-time = "2026-01-30T01:03:17.458Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/c9/c3161313b4ca0c601eeefabd3d3b576edaa9afdefd32da97210700e47652/pytokens-0.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:9bd7d7f544d362576be74f9d5901a22f317efc20046efe2034dced238cbbfe78", size = 103520, upload-time = "2026-01-30T01:03:18.652Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/a7/b470f672e6fc5fee0a01d9e75005a0e617e162381974213a945fcd274843/pytokens-0.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:4a14d5f5fc78ce85e426aa159489e2d5961acf0e47575e08f35584009178e321", size = 160821, upload-time = "2026-01-30T01:03:19.684Z" },
-    { url = "https://files.pythonhosted.org/packages/80/98/e83a36fe8d170c911f864bfded690d2542bfcfacb9c649d11a9e6eb9dc41/pytokens-0.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97f50fd18543be72da51dd505e2ed20d2228c74e0464e4262e4899797803d7fa", size = 254263, upload-time = "2026-01-30T01:03:20.834Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/95/70d7041273890f9f97a24234c00b746e8da86df462620194cef1d411ddeb/pytokens-0.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dc74c035f9bfca0255c1af77ddd2d6ae8419012805453e4b0e7513e17904545d", size = 268071, upload-time = "2026-01-30T01:03:21.888Z" },
-    { url = "https://files.pythonhosted.org/packages/da/79/76e6d09ae19c99404656d7db9c35dfd20f2086f3eb6ecb496b5b31163bad/pytokens-0.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f66a6bbe741bd431f6d741e617e0f39ec7257ca1f89089593479347cc4d13324", size = 271716, upload-time = "2026-01-30T01:03:23.633Z" },
-    { url = "https://files.pythonhosted.org/packages/79/37/482e55fa1602e0a7ff012661d8c946bafdc05e480ea5a32f4f7e336d4aa9/pytokens-0.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:b35d7e5ad269804f6697727702da3c517bb8a5228afa450ab0fa787732055fc9", size = 104539, upload-time = "2026-01-30T01:03:24.788Z" },
-    { url = "https://files.pythonhosted.org/packages/30/e8/20e7db907c23f3d63b0be3b8a4fd1927f6da2395f5bcc7f72242bb963dfe/pytokens-0.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8fcb9ba3709ff77e77f1c7022ff11d13553f3c30299a9fe246a166903e9091eb", size = 168474, upload-time = "2026-01-30T01:03:26.428Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/81/88a95ee9fafdd8f5f3452107748fd04c24930d500b9aba9738f3ade642cc/pytokens-0.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:79fc6b8699564e1f9b521582c35435f1bd32dd06822322ec44afdeba666d8cb3", size = 290473, upload-time = "2026-01-30T01:03:27.415Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/35/3aa899645e29b6375b4aed9f8d21df219e7c958c4c186b465e42ee0a06bf/pytokens-0.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d31b97b3de0f61571a124a00ffe9a81fb9939146c122c11060725bd5aea79975", size = 303485, upload-time = "2026-01-30T01:03:28.558Z" },
-    { url = "https://files.pythonhosted.org/packages/52/a0/07907b6ff512674d9b201859f7d212298c44933633c946703a20c25e9d81/pytokens-0.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:967cf6e3fd4adf7de8fc73cd3043754ae79c36475c1c11d514fc72cf5490094a", size = 306698, upload-time = "2026-01-30T01:03:29.653Z" },
-    { url = "https://files.pythonhosted.org/packages/39/2a/cbbf9250020a4a8dd53ba83a46c097b69e5eb49dd14e708f496f548c6612/pytokens-0.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:584c80c24b078eec1e227079d56dc22ff755e0ba8654d8383b2c549107528918", size = 116287, upload-time = "2026-01-30T01:03:30.912Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/78/397db326746f0a342855b81216ae1f0a32965deccfd7c830a2dbc66d2483/pytokens-0.4.1-py3-none-any.whl", hash = "sha256:26cef14744a8385f35d0e095dc8b3a7583f6c953c2e3d269c7f82484bf5ad2de", size = 13729, upload-time = "2026-01-30T01:03:45.029Z" },
-]
-
-[[package]]
 name = "pywinpty"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -3452,6 +3390,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/85/70/92482ccffb96f5441aab93e26c4d66489eb599efdcf96fad90c14bbfb976/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dbd936cde57abfee19ab3213cf9c26be06d60750e60a8e4dd85d1ab12c8b1f40", size = 556030, upload-time = "2025-11-30T20:24:10.956Z" },
     { url = "https://files.pythonhosted.org/packages/20/53/7c7e784abfa500a2b6b583b147ee4bb5a2b3747a9166bab52fec4b5b5e7d/rpds_py-0.30.0-cp314-cp314t-win32.whl", hash = "sha256:dc824125c72246d924f7f796b4f63c1e9dc810c7d9e2355864b3c3a73d59ade0", size = 211570, upload-time = "2025-11-30T20:24:12.735Z" },
     { url = "https://files.pythonhosted.org/packages/d0/02/fa464cdfbe6b26e0600b62c528b72d8608f5cc49f96b8d6e38c95d60c676/rpds_py-0.30.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27f4b0e92de5bfbc6f86e43959e6edd1425c33b5e69aab0984a72047f2bcf1e3", size = 226532, upload-time = "2025-11-30T20:24:14.634Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.16"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a6/bd/5f7ec371001337d8fa61701c186ff8b613ecac1651848c5950f4c4d5f2e9/ruff-0.15.16.tar.gz", hash = "sha256:d05e78d38c78caf020b03789e25106c93017db5a0cb6e2819885018c61343b78", size = 4714267, upload-time = "2026-06-04T16:33:09.974Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/42/53ef1c3953f157956db9bf7861e3bc50b9b887ce93300aa48cdba8336fe6/ruff-0.15.16-py3-none-linux_armv6l.whl", hash = "sha256:6ac3c0b3969cc6cf6b158c4e2f8f682acb58e7d700d8a44b65ecdc72d66ab0b2", size = 10709025, upload-time = "2026-06-04T16:32:51.935Z" },
+    { url = "https://files.pythonhosted.org/packages/93/9a/a79159346f19134a956607754e57d8d128f7a4c00f4ad2f7514d224c172c/ruff-0.15.16-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:197c207ed75ffba54a0dec23db4aa939a27a3053073e085e0042433cbdc58e4a", size = 11063550, upload-time = "2026-06-04T16:32:42.24Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/72/3ce2ac000a5299ec238e01f51397b3b653c93b077d9b1bfe8715bb895f20/ruff-0.15.16-py3-none-macosx_11_0_arm64.whl", hash = "sha256:3a39fec45ab316cc23e7558f23fea4a70403ddb5648ea9a4a3854a16973d0071", size = 10421345, upload-time = "2026-06-04T16:32:37.251Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/c2/cc7fad3ec9169373f5b6a18f1917b91080feec40c3f9658334a1d28e2f03/ruff-0.15.16-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ba93191d79003116b95128c9d306e045200fdbd0bccb782b110f3cd1d4abc5cf", size = 10757217, upload-time = "2026-06-04T16:32:54.722Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d2/3474009eaa0a65b31fa7152a2fad5e2f050c640ceb1e6b02ee6922e94c82/ruff-0.15.16-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c6ee4b90520630120ef032aa5cc10db483852dff950e78b1d717e2993a61ac8d", size = 10507035, upload-time = "2026-06-04T16:33:05.343Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/81/b7ae6ccbd11f0c8dc3d5d67fc4be9b57ff57ca86ba56152021378e1277f2/ruff-0.15.16-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4e4215bc938bc3c8215c1472c1aa437e310fee20cd427335fec9d7e609563628", size = 11255291, upload-time = "2026-06-04T16:32:49.49Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/e1/46e526f1a7cc90857ce6ddf25fbb77eb6568651ac38d71b033af07076dd5/ruff-0.15.16-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7c8d26be963b090f10e29abc8b3e74a2a321f6fa34e02424e30b5af89350ecbb", size = 12124922, upload-time = "2026-06-04T16:33:07.821Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/da/5c791b088b596b24d0deb967fa28ae02ad751a140c0b9ea81c5ab915d6c0/ruff-0.15.16-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f198cf4123602a2280ed46c307bcbafe41758d6fee5b456b6b6058ca1514b3b4", size = 11332186, upload-time = "2026-06-04T16:33:02.971Z" },
+    { url = "https://files.pythonhosted.org/packages/72/11/5da87abe20047c8962361473923ebb2f62b595250126aadfad8c20649c1e/ruff-0.15.16-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bb27515fa6240fb586ae82b901a59e67d24acff86f2190b433dc542fe0435aeb", size = 11373541, upload-time = "2026-06-04T16:32:47.007Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/2a/8554754c23a854ae3fd6b507e36ad61ddb121e298c6d5d617dec94ed0f14/ruff-0.15.16-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:a267c46ba1593fc26b8eecbea050b39d40c0b6bb7781ee11c90a02cd10032951", size = 11353014, upload-time = "2026-06-04T16:32:34.795Z" },
+    { url = "https://files.pythonhosted.org/packages/62/25/62ea41529ec89f742ea3fed9cb1059c72877ec7cf9b9e99ac9cf3294d1d9/ruff-0.15.16-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:528c68f39a91498a8d50e91ff5985df3d105782bab49cc378e73ac26bff083e8", size = 10737467, upload-time = "2026-06-04T16:32:26.348Z" },
+    { url = "https://files.pythonhosted.org/packages/90/17/334d3ad9de4d40f9dd58fdd09e35ce64553bb501e2f19a839e2fb6be14fc/ruff-0.15.16-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:7ed55c58950df60589a9a7a5d2f8fa5f54ebd287163be805adfe6ee95a9de123", size = 10521910, upload-time = "2026-06-04T16:32:32.54Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/bd/3ac7c6ae77a885c1004b3dda2446ea401768d24f851c14b4ad4b24f6639c/ruff-0.15.16-py3-none-musllinux_1_2_i686.whl", hash = "sha256:d482feaf51512b50f9790ceb417a56a61dd1e9d9bf967662b9ed27c01b34f53a", size = 10979190, upload-time = "2026-06-04T16:32:57.492Z" },
+    { url = "https://files.pythonhosted.org/packages/33/d7/609546e6a413c3f216fbf2a50c928f97c80939154f6a0503114094a86191/ruff-0.15.16-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:1e15bc8c94513dae2a40cc9ef07c94fdd4ecc9e29dabebeebe170f952322c9e3", size = 11477014, upload-time = "2026-06-04T16:32:44.687Z" },
+    { url = "https://files.pythonhosted.org/packages/74/0d/f2cd247ad32633a5c36e97141a2c21b11c6279f7957bc2ff360b1e08fddd/ruff-0.15.16-py3-none-win32.whl", hash = "sha256:580378f7bd4aa25f72e74aa54948a9622f142b1e509521dd10902e886681cc1e", size = 10735541, upload-time = "2026-06-04T16:32:30.145Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9e/02e845ef151b1dee585e55c4739f8e1734ae1d9f1221dff65761c162208b/ruff-0.15.16-py3-none-win_amd64.whl", hash = "sha256:408256017284eddf98fff77b29aa4fb30f586042d535b2d9befc6512f400aaec", size = 11843403, upload-time = "2026-06-04T16:32:39.76Z" },
+    { url = "https://files.pythonhosted.org/packages/15/19/016553f86f207450aebebc2b2b5088d086b901cc8186c02ac4284db3bd88/ruff-0.15.16-py3-none-win_arm64.whl", hash = "sha256:8cd61783afb39638a7133ef0d2dfb1e91277593962f81b5a8423eb0b888a6121", size = 11134555, upload-time = "2026-06-04T16:33:00.136Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Replace the Black + isort toolchain with Ruff for linting, import sorting, and formatting (line-length 100), and resolve the pre-existing lint findings Ruff surfaced.

- Swap dev dependencies and tool config in `pyproject.toml`; enable `E`/`F`/`I` rules
- Update pre-commit hooks, CI lint steps, and `scripts/format.sh` to use Ruff
- Add documented per-file ignores for the Streamlit entry point (`E402`) and import smoke tests (`F401`)
- Fix pre-existing findings (unused imports/variables, bare `except`, long lines) without altering prompt or message content
- Update README to reference Ruff

Testing: `ruff check`, `ruff format --check`, and `pytest` (296 passed) all green; pre-commit hooks pass.

Refs: JSA-53