### PR TITLE
refactor(config): inline LLM settings per agent task

### DIFF
--- a/configs/base.toml
+++ b/configs/base.toml
@@ -15,37 +15,37 @@ format = "%(asctime)s %(name)s [%(levelname)s] %(message)s"
 # Each agent task directly defines the LLM it uses (provider, model, and settings).
 # Tasks may share the same model with different settings (e.g. temperature) simply
 # by repeating the model with different values below.
-[agents.job_evaluation_extraction]
+[agent_tasks.job_evaluation_extraction]
 provider = "google"
 model = "gemini-2.5-flash"
 temperature = 0.0
 max_tokens = 4096
 
-[agents.job_evaluation_fit]
+[agent_tasks.job_evaluation_fit]
 provider = "google"
 model = "gemini-2.5-flash"
 temperature = 0.0
 max_tokens = 4096
 
-[agents.interview_research]
+[agent_tasks.interview_research]
 provider = "google"
 model = "gemini-2.5-flash-lite"
 temperature = 0.7
 max_tokens = 4096
 
-[agents.interview_question_generation]
+[agent_tasks.interview_question_generation]
 provider = "google"
 model = "gemini-2.5-flash-lite"
 temperature = 0.7
 max_tokens = 4096
 
-[agents.interview_answer_generation]
+[agent_tasks.interview_answer_generation]
 provider = "google"
 model = "gemini-2.5-flash-lite"
 temperature = 0.7
 max_tokens = 4096
 
-[agents.interview_compilation]
+[agent_tasks.interview_compilation]
 provider = "google"
 model = "gemini-2.5-flash-lite"
 temperature = 0.7

--- a/configs/base.toml
+++ b/configs/base.toml
@@ -12,56 +12,44 @@ debug = false
 level = "INFO"
 format = "%(asctime)s %(name)s [%(levelname)s] %(message)s"
 
-[llm_profiles.anthropic_extraction]
-provider = "anthropic"
-model = "claude-haiku-4-5"
-temperature = 0.0
-max_tokens = 512
-
-[llm_profiles.google_extraction]
-provider = "google"
-model = "gemini-2.5-flash"
-temperature = 0.0
-max_tokens = 512
-
-[llm_profiles.google_job_evaluation]
+# Each agent task directly defines the LLM it uses (provider, model, and settings).
+# Tasks may share the same model with different settings (e.g. temperature) simply
+# by repeating the model with different values below.
+[agents.job_evaluation_extraction]
 provider = "google"
 model = "gemini-2.5-flash"
 temperature = 0.0
 max_tokens = 4096
 
-[llm_profiles.google_interview_research]
+[agents.job_evaluation_fit]
 provider = "google"
-model = "gemini-2.5-pro"
-temperature = 0.2
+model = "gemini-2.5-flash"
+temperature = 0.0
 max_tokens = 4096
 
-[llm_profiles.google_interview_generation]
-provider = "google"
-model = "gemini-2.5-pro"
-temperature = 0.7
-max_tokens = 8192
-
-[llm_profiles.anthropic_interview_generation]
-provider = "anthropic"
-model = "claude-haiku-4-5"
-temperature = 0.7
-max_tokens = 1024
-
-[llm_profiles.google_flash_lite]
+[agents.interview_research]
 provider = "google"
 model = "gemini-2.5-flash-lite"
 temperature = 0.7
 max_tokens = 4096
 
-# Agent task to LLM profile mapping
-[agents]
-job_evaluation_extraction = "google_job_evaluation"
-job_evaluation_fit = "google_job_evaluation"
-interview_research = "google_flash_lite"
-interview_question_generation = "google_flash_lite"
-interview_answer_generation = "google_flash_lite"
-interview_compilation = "google_flash_lite"
+[agents.interview_question_generation]
+provider = "google"
+model = "gemini-2.5-flash-lite"
+temperature = 0.7
+max_tokens = 4096
+
+[agents.interview_answer_generation]
+provider = "google"
+model = "gemini-2.5-flash-lite"
+temperature = 0.7
+max_tokens = 4096
+
+[agents.interview_compilation]
+provider = "google"
+model = "gemini-2.5-flash-lite"
+temperature = 0.7
+max_tokens = 4096
 
 [observability.langfuse]
 enabled = false

--- a/docs/design/configuration.md
+++ b/docs/design/configuration.md
@@ -105,10 +105,10 @@ model = "gemini-2.5-flash"
 provider = "google"
 model = "gemini-2.5-flash-lite"
 ```
-Each task becomes an `LLMProfileConfig` accessible via **attributes** on
+Each task becomes an `LLMConfig` accessible via **attributes** on
 `config.agent_tasks`:
 ```python
-config.agent_tasks.job_evaluation_extraction          # ✅ LLMProfileConfig
+config.agent_tasks.job_evaluation_extraction          # ✅ LLMConfig
 config.agent_tasks.job_evaluation_extraction.provider  # ✅ Attribute access
 config.agent_tasks.job_evaluation_extraction.model     # ✅ Attribute access
 ```
@@ -116,7 +116,7 @@ config.agent_tasks.job_evaluation_extraction.model     # ✅ Attribute access
 ### Why This Design?
 
 - **Intuitive**: The model a task uses is defined in one place, not via an indirection layer
-- **Type Safety**: Each task's LLM settings are validated as an `LLMProfileConfig` Pydantic model
+- **Type Safety**: Each task's LLM settings are validated as an `LLMConfig` Pydantic model
 - **Per-task flexibility**: Two tasks can share a model with different settings (e.g. temperature) without inventing distinct profile names, and overrides in `dev.toml`/`prod.toml` apply per task
 
 ## Configuration Loading Strategy
@@ -162,7 +162,7 @@ min_salary = config.evaluation_criteria.min_salary
 
 # The config proxy provides lazy loading - configuration is loaded automatically
 # on first access and cached for subsequent uses.
-# Each agent task carries its own LLM config (an LLMProfileConfig):
+# Each agent task carries its own LLM config (an LLMConfig):
 extraction_llm = config.agent_tasks.job_evaluation_extraction
 model = get_chat_model(extraction_llm)
 ```

--- a/docs/design/configuration.md
+++ b/docs/design/configuration.md
@@ -44,19 +44,22 @@ level = "INFO"
 format = "%(asctime)s %(name)s [%(levelname)s] %(message)s"
 ```
 
-#### LLM Profiles
+#### Agent LLM Configuration
+Each agent task directly defines the LLM it uses (provider, model, and
+sampling settings). Two tasks can share the same model with different
+settings simply by repeating the model with different values.
 ```toml
-[llm_profiles.anthropic_extraction]
-provider = "anthropic"
-model = "claude-haiku-4-5"
+[agents.job_evaluation_extraction]
+provider = "google"
+model = "gemini-2.5-flash"
 temperature = 0.0
-max_tokens = 512
-```
+max_tokens = 4096
 
-#### Agent Mappings
-```toml
-[agents]
-job_evaluation_extraction = "anthropic_extraction"
+[agents.interview_question_generation]
+provider = "google"
+model = "gemini-2.5-flash-lite"
+temperature = 0.7
+max_tokens = 4096
 ```
 
 #### Business Logic Parameters
@@ -92,33 +95,29 @@ config.evaluation_criteria.min_salary        # ✅ Works
 config.evaluation_criteria.remote_required   # ✅ Works
 ```
 
-#### 2. Table Arrays → Dictionaries (Dictionary Access)
+#### 2. Per-Task LLM Config → Pydantic Models (Attribute Access)
 ```toml
-[llm_profiles.anthropic_extraction]
-provider = "anthropic"
-model = "claude-haiku-4-5"
+[agents.job_evaluation_extraction]
+provider = "google"
+model = "gemini-2.5-flash"
 
-[llm_profiles.another_profile]
-provider = "openai"
-model = "gpt-4"
+[agents.interview_question_generation]
+provider = "google"
+model = "gemini-2.5-flash-lite"
 ```
-Creates a **dictionary** of profile configurations:
+Each task becomes an `LLMProfileConfig` accessible via **attributes** on
+`config.agents`:
 ```python
-config.llm_profiles["anthropic_extraction"]  # ✅ Dictionary access required
-config.llm_profiles.anthropic_extraction     # ❌ AttributeError: 'dict' has no attribute
-
-# Each profile is then a Pydantic model:
-profile = config.llm_profiles["anthropic_extraction"]
-profile.provider  # ✅ Attribute access works on the individual profile
-profile.model     # ✅ Attribute access works on the individual profile
+config.agents.job_evaluation_extraction          # ✅ LLMProfileConfig
+config.agents.job_evaluation_extraction.provider  # ✅ Attribute access
+config.agents.job_evaluation_extraction.model     # ✅ Attribute access
 ```
 
 ### Why This Design?
 
-- **Dynamic Profile Names**: LLM profiles can have arbitrary names (e.g., "anthropic_extraction", "openai_chat")
-- **Type Safety**: Each profile is validated as an `LLMProfileConfig` Pydantic model
-- **Flexibility**: Easy to add new profiles without code changes
-- **Helper Methods**: Use `config.get_llm_profile(name)` for validated access with better error messages
+- **Intuitive**: The model a task uses is defined in one place, not via an indirection layer
+- **Type Safety**: Each task's LLM settings are validated as an `LLMProfileConfig` Pydantic model
+- **Per-task flexibility**: Two tasks can share a model with different settings (e.g. temperature) without inventing distinct profile names, and overrides in `dev.toml`/`prod.toml` apply per task
 
 ## Configuration Loading Strategy
 
@@ -159,13 +158,13 @@ Pydantic models in `src/config/models.py` define:
 from src.config.manager import config
 
 # Access typed configuration values directly
-llm_profile = config.llm_profiles["anthropic_extraction"]  # Dictionary access for profiles
 min_salary = config.evaluation_criteria.min_salary
 
 # The config proxy provides lazy loading - configuration is loaded automatically
-# on first access and cached for subsequent uses
-agent_profile_name = config.agents.job_evaluation_extraction
-agent_profile = config.get_llm_profile(agent_profile_name)  # Helper method handles dict access
+# on first access and cached for subsequent uses.
+# Each agent task carries its own LLM config (an LLMProfileConfig):
+extraction_llm = config.agents.job_evaluation_extraction
+model = get_chat_model(extraction_llm)
 ```
 
 ## Benefits of This Design

--- a/docs/design/configuration.md
+++ b/docs/design/configuration.md
@@ -49,13 +49,13 @@ Each agent task directly defines the LLM it uses (provider, model, and
 sampling settings). Two tasks can share the same model with different
 settings simply by repeating the model with different values.
 ```toml
-[agents.job_evaluation_extraction]
+[agent_tasks.job_evaluation_extraction]
 provider = "google"
 model = "gemini-2.5-flash"
 temperature = 0.0
 max_tokens = 4096
 
-[agents.interview_question_generation]
+[agent_tasks.interview_question_generation]
 provider = "google"
 model = "gemini-2.5-flash-lite"
 temperature = 0.7
@@ -97,20 +97,20 @@ config.evaluation_criteria.remote_required   # ✅ Works
 
 #### 2. Per-Task LLM Config → Pydantic Models (Attribute Access)
 ```toml
-[agents.job_evaluation_extraction]
+[agent_tasks.job_evaluation_extraction]
 provider = "google"
 model = "gemini-2.5-flash"
 
-[agents.interview_question_generation]
+[agent_tasks.interview_question_generation]
 provider = "google"
 model = "gemini-2.5-flash-lite"
 ```
 Each task becomes an `LLMProfileConfig` accessible via **attributes** on
-`config.agents`:
+`config.agent_tasks`:
 ```python
-config.agents.job_evaluation_extraction          # ✅ LLMProfileConfig
-config.agents.job_evaluation_extraction.provider  # ✅ Attribute access
-config.agents.job_evaluation_extraction.model     # ✅ Attribute access
+config.agent_tasks.job_evaluation_extraction          # ✅ LLMProfileConfig
+config.agent_tasks.job_evaluation_extraction.provider  # ✅ Attribute access
+config.agent_tasks.job_evaluation_extraction.model     # ✅ Attribute access
 ```
 
 ### Why This Design?
@@ -163,7 +163,7 @@ min_salary = config.evaluation_criteria.min_salary
 # The config proxy provides lazy loading - configuration is loaded automatically
 # on first access and cached for subsequent uses.
 # Each agent task carries its own LLM config (an LLMProfileConfig):
-extraction_llm = config.agents.job_evaluation_extraction
+extraction_llm = config.agent_tasks.job_evaluation_extraction
 model = get_chat_model(extraction_llm)
 ```
 

--- a/docs/design/llm-factory-pattern.md
+++ b/docs/design/llm-factory-pattern.md
@@ -212,11 +212,11 @@ VALID_MODELS: ClassVar[Dict[str, set]] = {
 }
 ```
 
-**Step 4**: Add configuration profile
+**Step 4**: Point an agent task at the new provider
 
 ```toml
 # configs/base.toml
-[llm_profiles.openai_extraction]
+[agents.job_evaluation_extraction]
 provider = "openai"
 model = "gpt-4"
 temperature = 0.0
@@ -323,33 +323,40 @@ register_provider("invalid", "path.to.InvalidClient")
 
 ## Configuration Integration
 
-### Profile-Based Usage
+### Task-Based Usage
 
-```python
+Each agent task defines its own LLM config inline; application code passes
+that config straight to the factory.
+
+```toml
 # configs/base.toml
-[agents]
-job_evaluation_extraction = "anthropic_extraction"
-
-[llm_profiles.anthropic_extraction]
+[agents.job_evaluation_extraction]
 provider = "anthropic"
 model = "claude-haiku-4-5"
 temperature = 0.0
 max_tokens = 512
-
-# Application code
-from src.llm import get_llm_client_by_profile_name
-client = get_llm_client_by_profile_name("anthropic_extraction")
 ```
 
-### Environment-Specific Providers
+```python
+# Application code
+from src.config import config
+from src.llm import get_chat_model
+
+model = get_chat_model(config.agents.job_evaluation_extraction)
+```
+
+### Environment-Specific Overrides
+
+Overrides apply per task, so you can change a single setting without
+affecting other tasks that happen to use the same model.
 
 ```toml
 # configs/dev.toml - Development environment
-[llm_profiles.extraction]
+[agents.job_evaluation_extraction]
 provider = "anthropic"  # Use real provider in dev
 
 # configs/stage.toml - Testing environment
-[llm_profiles.extraction]
+[agents.job_evaluation_extraction]
 provider = "mock"  # Use mock provider in testing
 ```
 

--- a/docs/design/llm-factory-pattern.md
+++ b/docs/design/llm-factory-pattern.md
@@ -68,10 +68,10 @@ graph TD
 
 ```python
 from src.llm import get_llm_client
-from src.config.models import LLMProfileConfig
+from src.config.models import LLMConfig
 
 # Create client via factory
-config = LLMProfileConfig(
+config = LLMConfig(
     provider="anthropic",
     model="claude-haiku-4-5",
     api_key="your-api-key"
@@ -170,7 +170,7 @@ from src.utils.singleton import singleton
 class OpenAIClient(BaseLLMClient):
     """OpenAI LLM client implementation."""
 
-    def __init__(self, config: LLMProfileConfig):
+    def __init__(self, config: LLMConfig):
         super().__init__(config)
 
         if config.provider != "openai":
@@ -279,7 +279,7 @@ def test_feature_with_mock_llm():
     factory = LLMClientFactory()
     factory.register_provider("mock", "tests.mocks.mock_client.MockLLMClient")
 
-    config = LLMProfileConfig(provider="mock", model="test", api_key="test")
+    config = LLMConfig(provider="mock", model="test", api_key="test")
     client = factory.create_client(config)
     # Test your feature...
 ```

--- a/docs/design/llm-factory-pattern.md
+++ b/docs/design/llm-factory-pattern.md
@@ -216,7 +216,7 @@ VALID_MODELS: ClassVar[Dict[str, set]] = {
 
 ```toml
 # configs/base.toml
-[agents.job_evaluation_extraction]
+[agent_tasks.job_evaluation_extraction]
 provider = "openai"
 model = "gpt-4"
 temperature = 0.0
@@ -330,7 +330,7 @@ that config straight to the factory.
 
 ```toml
 # configs/base.toml
-[agents.job_evaluation_extraction]
+[agent_tasks.job_evaluation_extraction]
 provider = "anthropic"
 model = "claude-haiku-4-5"
 temperature = 0.0
@@ -342,7 +342,7 @@ max_tokens = 512
 from src.config import config
 from src.llm import get_chat_model
 
-model = get_chat_model(config.agents.job_evaluation_extraction)
+model = get_chat_model(config.agent_tasks.job_evaluation_extraction)
 ```
 
 ### Environment-Specific Overrides
@@ -352,11 +352,11 @@ affecting other tasks that happen to use the same model.
 
 ```toml
 # configs/dev.toml - Development environment
-[agents.job_evaluation_extraction]
+[agent_tasks.job_evaluation_extraction]
 provider = "anthropic"  # Use real provider in dev
 
 # configs/stage.toml - Testing environment
-[agents.job_evaluation_extraction]
+[agent_tasks.job_evaluation_extraction]
 provider = "mock"  # Use mock provider in testing
 ```
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -106,12 +106,13 @@ The application uses TOML configuration files in the `configs/` directory:
 ### Key Configuration Areas
 
 #### LLM Settings
+Each agent task defines its own LLM provider, model, and sampling settings.
 ```toml
-[llm_profiles.anthropic_extraction]
-provider = "anthropic"
-model = "claude-haiku-4-5"
+[agents.job_evaluation_extraction]
+provider = "google"
+model = "gemini-2.5-flash"
 temperature = 0.0
-max_tokens = 512
+max_tokens = 4096
 ```
 
 #### Evaluation Criteria

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -108,7 +108,7 @@ The application uses TOML configuration files in the `configs/` directory:
 #### LLM Settings
 Each agent task defines its own LLM provider, model, and sampling settings.
 ```toml
-[agents.job_evaluation_extraction]
+[agent_tasks.job_evaluation_extraction]
 provider = "google"
 model = "gemini-2.5-flash"
 temperature = 0.0

--- a/src/agent/tools/extraction/schema_extraction_tool.py
+++ b/src/agent/tools/extraction/schema_extraction_tool.py
@@ -20,7 +20,7 @@ logger = get_logger(__name__)
 
 def _get_extraction_model():
     """Get the LangChain chat model configured for extraction."""
-    return get_chat_model(config.agents.job_evaluation_extraction)
+    return get_chat_model(config.agent_tasks.job_evaluation_extraction)
 
 
 def _extract_with_schema(

--- a/src/agent/tools/extraction/schema_extraction_tool.py
+++ b/src/agent/tools/extraction/schema_extraction_tool.py
@@ -11,7 +11,7 @@ from langchain_core.messages import HumanMessage
 
 from src.agent.prompts.extraction.job_posting import JOB_POSTING_EXTRACTION_PROMPT
 from src.config import config
-from src.llm import get_chat_model_by_profile_name, langfuse_manager
+from src.llm import get_chat_model, langfuse_manager
 from src.models.job import JobPostingExtractionSchema
 from src.utils.logging import get_logger
 
@@ -20,8 +20,7 @@ logger = get_logger(__name__)
 
 def _get_extraction_model():
     """Get the LangChain chat model configured for extraction."""
-    profile_name = config.agents.job_evaluation_extraction
-    return get_chat_model_by_profile_name(profile_name)
+    return get_chat_model(config.agents.job_evaluation_extraction)
 
 
 def _extract_with_schema(

--- a/src/agent/workflows/interview_prep/main.py
+++ b/src/agent/workflows/interview_prep/main.py
@@ -121,7 +121,7 @@ def generate_questions(state: InterviewPrepState) -> Dict[str, Any]:
     logger.info("Generating interview questions")
 
     try:
-        llm = get_chat_model(config.agents.interview_question_generation)
+        llm = get_chat_model(config.agent_tasks.interview_question_generation)
         structured_llm = llm.with_structured_output(InterviewQuestions)
 
         # Create system prompt for question generation
@@ -199,7 +199,7 @@ def generate_answers(state: InterviewPrepState) -> Dict[str, Any]:
         return {"error": "No questions available for answer generation"}
 
     try:
-        llm = get_chat_model(config.agents.interview_answer_generation)
+        llm = get_chat_model(config.agent_tasks.interview_answer_generation)
 
         updated_qa_pairs = []
 

--- a/src/agent/workflows/interview_prep/main.py
+++ b/src/agent/workflows/interview_prep/main.py
@@ -18,7 +18,7 @@ from src.agent.tools.pii_redaction import pii_pipeline
 from src.agent.tools.research import research_tool
 from src.agent.workflows.interview_prep.states import InterviewPrepState
 from src.config import config
-from src.llm import get_chat_model_by_profile_name, langfuse_manager
+from src.llm import get_chat_model, langfuse_manager
 from src.models.interview import (
     AnswerItem,
     AnswerStyle,
@@ -121,7 +121,7 @@ def generate_questions(state: InterviewPrepState) -> Dict[str, Any]:
     logger.info("Generating interview questions")
 
     try:
-        llm = get_chat_model_by_profile_name(config.agents.interview_question_generation)
+        llm = get_chat_model(config.agents.interview_question_generation)
         structured_llm = llm.with_structured_output(InterviewQuestions)
 
         # Create system prompt for question generation
@@ -199,7 +199,7 @@ def generate_answers(state: InterviewPrepState) -> Dict[str, Any]:
         return {"error": "No questions available for answer generation"}
 
     try:
-        llm = get_chat_model_by_profile_name(config.agents.interview_answer_generation)
+        llm = get_chat_model(config.agents.interview_answer_generation)
 
         updated_qa_pairs = []
 

--- a/src/config/loader.py
+++ b/src/config/loader.py
@@ -174,17 +174,17 @@ class ConfigLoader:
             langfuse_config["public_key"] = os.getenv("LANGFUSE_PUBLIC_KEY")
             langfuse_config["secret_key"] = os.getenv("LANGFUSE_SECRET_KEY")
 
-        # Load LLM API keys for each profile
-        if "llm_profiles" in config:
-            for profile_name, profile_config in config["llm_profiles"].items():
-                provider = profile_config.get("provider", "").lower()
+        # Load LLM API keys for each agent task based on its provider
+        if "agents" in config:
+            for _task_name, agent_config in config["agents"].items():
+                provider = agent_config.get("provider", "").lower()
 
                 if provider == "anthropic":
-                    profile_config["api_key"] = os.getenv("ANTHROPIC_API_KEY")
+                    agent_config["api_key"] = os.getenv("ANTHROPIC_API_KEY")
                 elif provider == "fireworks":
-                    profile_config["api_key"] = os.getenv("FIREWORKS_API_KEY")
+                    agent_config["api_key"] = os.getenv("FIREWORKS_API_KEY")
                 elif provider == "google":
-                    profile_config["api_key"] = os.getenv("GOOGLE_API_KEY")
+                    agent_config["api_key"] = os.getenv("GOOGLE_API_KEY")
 
         return config
 

--- a/src/config/loader.py
+++ b/src/config/loader.py
@@ -175,8 +175,8 @@ class ConfigLoader:
             langfuse_config["secret_key"] = os.getenv("LANGFUSE_SECRET_KEY")
 
         # Load LLM API keys for each agent task based on its provider
-        if "agents" in config:
-            for _task_name, agent_config in config["agents"].items():
+        if "agent_tasks" in config:
+            for _task_name, agent_config in config["agent_tasks"].items():
                 provider = agent_config.get("provider", "").lower()
 
                 if provider == "anthropic":

--- a/src/config/models.py
+++ b/src/config/models.py
@@ -151,7 +151,7 @@ class LLMProfileConfig(BaseModel):
         )
 
 
-class AgentConfig(BaseModel):
+class AgentTasksConfig(BaseModel):
     """LLM configuration for each agent task.
 
     Each task directly carries its own provider, model, and sampling settings.
@@ -207,5 +207,5 @@ class AppConfig(BaseModel):
 
     general: GeneralConfig = Field(..., description="General application configuration")
     logging: LoggingConfig = Field(..., description="Logging configuration")
-    agents: AgentConfig = Field(..., description="Agent configuration")
+    agent_tasks: AgentTasksConfig = Field(..., description="Per-task LLM configuration")
     observability: ObservabilityConfig = Field(..., description="Observability configuration")

--- a/src/config/models.py
+++ b/src/config/models.py
@@ -41,7 +41,7 @@ class LoggingConfig(BaseModel):
         return v.upper()
 
 
-class LLMProfileConfig(BaseModel):
+class LLMConfig(BaseModel):
     """Configuration for a single LLM (provider, model, and sampling settings)."""
 
     provider: str = Field(..., description="LLM provider")
@@ -127,7 +127,7 @@ class LLMProfileConfig(BaseModel):
         return v
 
     def __hash__(self) -> int:
-        """Make LLMProfileConfig hashable for use in singleton pattern."""
+        """Make LLMConfig hashable for use in singleton pattern."""
         return hash(
             (
                 self.provider,
@@ -139,8 +139,8 @@ class LLMProfileConfig(BaseModel):
         )
 
     def __eq__(self, other) -> bool:
-        """Define equality for LLMProfileConfig objects."""
-        if not isinstance(other, LLMProfileConfig):
+        """Define equality for LLMConfig objects."""
+        if not isinstance(other, LLMConfig):
             return False
         return (
             self.provider == other.provider
@@ -157,24 +157,18 @@ class AgentTasksConfig(BaseModel):
     Each task directly carries its own provider, model, and sampling settings.
     """
 
-    job_evaluation_extraction: LLMProfileConfig = Field(
+    job_evaluation_extraction: LLMConfig = Field(
         ..., description="LLM config for job information extraction"
     )
-    job_evaluation_fit: LLMProfileConfig = Field(
-        ..., description="LLM config for the job fit assessment"
-    )
-    interview_research: LLMProfileConfig = Field(
-        ..., description="LLM config for interview research"
-    )
-    interview_question_generation: LLMProfileConfig = Field(
+    job_evaluation_fit: LLMConfig = Field(..., description="LLM config for the job fit assessment")
+    interview_research: LLMConfig = Field(..., description="LLM config for interview research")
+    interview_question_generation: LLMConfig = Field(
         ..., description="LLM config for question generation"
     )
-    interview_answer_generation: LLMProfileConfig = Field(
+    interview_answer_generation: LLMConfig = Field(
         ..., description="LLM config for answer generation"
     )
-    interview_compilation: LLMProfileConfig = Field(
-        ..., description="LLM config for guide compilation"
-    )
+    interview_compilation: LLMConfig = Field(..., description="LLM config for guide compilation")
 
 
 class LangfuseConfig(BaseModel):

--- a/src/config/models.py
+++ b/src/config/models.py
@@ -41,39 +41,8 @@ class LoggingConfig(BaseModel):
         return v.upper()
 
 
-class AgentConfig(BaseModel):
-    """Agent task to LLM profile mappings."""
-
-    # Existing
-    job_evaluation_extraction: str = Field(
-        ..., description="LLM profile for job information extraction"
-    )
-    job_evaluation_fit: str = Field(
-        default="google_job_evaluation",
-        description="LLM profile for the job fit assessment",
-    )
-
-    # New interview preparation agents
-    interview_research: str = Field(
-        default="google_interview_research",
-        description="LLM profile for interview research",
-    )
-    interview_question_generation: str = Field(
-        default="google_interview_generation",
-        description="LLM profile for question generation",
-    )
-    interview_answer_generation: str = Field(
-        default="google_interview_generation",
-        description="LLM profile for answer generation",
-    )
-    interview_compilation: str = Field(
-        default="google_interview_generation",
-        description="LLM profile for guide compilation",
-    )
-
-
 class LLMProfileConfig(BaseModel):
-    """Configuration for a single LLM profile."""
+    """Configuration for a single LLM (provider, model, and sampling settings)."""
 
     provider: str = Field(..., description="LLM provider")
     model: str = Field(..., description="Model identifier")
@@ -182,6 +151,32 @@ class LLMProfileConfig(BaseModel):
         )
 
 
+class AgentConfig(BaseModel):
+    """LLM configuration for each agent task.
+
+    Each task directly carries its own provider, model, and sampling settings.
+    """
+
+    job_evaluation_extraction: LLMProfileConfig = Field(
+        ..., description="LLM config for job information extraction"
+    )
+    job_evaluation_fit: LLMProfileConfig = Field(
+        ..., description="LLM config for the job fit assessment"
+    )
+    interview_research: LLMProfileConfig = Field(
+        ..., description="LLM config for interview research"
+    )
+    interview_question_generation: LLMProfileConfig = Field(
+        ..., description="LLM config for question generation"
+    )
+    interview_answer_generation: LLMProfileConfig = Field(
+        ..., description="LLM config for answer generation"
+    )
+    interview_compilation: LLMProfileConfig = Field(
+        ..., description="LLM config for guide compilation"
+    )
+
+
 class LangfuseConfig(BaseModel):
     """Langfuse observability configuration."""
 
@@ -213,22 +208,4 @@ class AppConfig(BaseModel):
     general: GeneralConfig = Field(..., description="General application configuration")
     logging: LoggingConfig = Field(..., description="Logging configuration")
     agents: AgentConfig = Field(..., description="Agent configuration")
-    llm_profiles: Dict[str, LLMProfileConfig] = Field(..., description="LLM profile configurations")
     observability: ObservabilityConfig = Field(..., description="Observability configuration")
-
-    def get_llm_profile(self, profile_name: str) -> LLMProfileConfig:
-        """Get LLM profile by name with validation."""
-        if profile_name not in self.llm_profiles:
-            available = ", ".join(self.llm_profiles.keys())
-            raise ValueError(
-                f"LLM profile '{profile_name}' not found. Available profiles: {available}"
-            )
-        return self.llm_profiles[profile_name]
-
-    def get_agent_llm_profile(self, agent_task: str) -> LLMProfileConfig:
-        """Get LLM profile for a specific agent task."""
-        if not hasattr(self.agents, agent_task):
-            raise ValueError(f"Unknown agent task: {agent_task}")
-
-        profile_name = getattr(self.agents, agent_task)
-        return self.get_llm_profile(profile_name)

--- a/src/core/job_evaluation/fit_evaluator.py
+++ b/src/core/job_evaluation/fit_evaluator.py
@@ -13,7 +13,7 @@ from pydantic import BaseModel, Field
 
 from src.agent.prompts.evaluation.fit import FIT_ASSESSMENT_PROMPT
 from src.config import config
-from src.llm import get_chat_model_by_profile_name, langfuse_manager
+from src.llm import get_chat_model, langfuse_manager
 from src.models.user import JobPreferences, NonePolicy
 from src.utils.logging import get_logger
 from src.utils.text import MAX_ROLE_DESCRIPTION_CHARS, truncate_text
@@ -75,7 +75,7 @@ def evaluate_fit(job_posting_text: str, preferences: JobPreferences) -> Dict[str
     # isolation guarantee independent of how the caller wraps the call.
     logger.info("Assessing job fit via LLM")
     try:
-        model = get_chat_model_by_profile_name(config.agents.job_evaluation_fit)
+        model = get_chat_model(config.agents.job_evaluation_fit)
         structured_llm = model.with_structured_output(FitAssessment)
         prompt_content = FIT_ASSESSMENT_PROMPT.format(
             target_role_description=truncate_text(

--- a/src/core/job_evaluation/fit_evaluator.py
+++ b/src/core/job_evaluation/fit_evaluator.py
@@ -75,7 +75,7 @@ def evaluate_fit(job_posting_text: str, preferences: JobPreferences) -> Dict[str
     # isolation guarantee independent of how the caller wraps the call.
     logger.info("Assessing job fit via LLM")
     try:
-        model = get_chat_model(config.agents.job_evaluation_fit)
+        model = get_chat_model(config.agent_tasks.job_evaluation_fit)
         structured_llm = model.with_structured_output(FitAssessment)
         prompt_content = FIT_ASSESSMENT_PROMPT.format(
             target_role_description=truncate_text(

--- a/src/llm/__init__.py
+++ b/src/llm/__init__.py
@@ -1,16 +1,15 @@
 """
 LLM client modules for the Job Search Assistant application.
 
-Provides get_chat_model() and get_chat_model_by_profile_name() to create
-configured LangChain BaseChatModel instances for different providers.
+Provides get_chat_model() to create configured LangChain BaseChatModel
+instances for different providers.
 """
 
-from src.llm.factory import get_chat_model, get_chat_model_by_profile_name
+from src.llm.factory import get_chat_model
 from src.llm.langfuse import GlobalLangfuseManager, LangfuseManager, langfuse_manager
 
 __all__ = [
     "get_chat_model",
-    "get_chat_model_by_profile_name",
     "LangfuseManager",
     "GlobalLangfuseManager",
     "langfuse_manager",

--- a/src/llm/factory.py
+++ b/src/llm/factory.py
@@ -9,7 +9,7 @@ import os
 
 from langchain_core.language_models import BaseChatModel
 
-from src.config.models import LLMProfileConfig
+from src.config.models import LLMConfig
 from src.exceptions.llm import LLMProviderError
 from src.utils.logging import get_logger
 
@@ -21,7 +21,7 @@ _PROVIDER_CONSTRUCTORS = {
 }
 
 
-def _ensure_api_key(config: LLMProfileConfig, env_var_name: str) -> str:
+def _ensure_api_key(config: LLMConfig, env_var_name: str) -> str:
     """Get API key from config or environment, raising if missing."""
     api_key = getattr(config, "api_key", None)
     if not api_key:
@@ -35,7 +35,7 @@ def _ensure_api_key(config: LLMProfileConfig, env_var_name: str) -> str:
     return api_key
 
 
-def _create_anthropic_model(config: LLMProfileConfig) -> BaseChatModel:
+def _create_anthropic_model(config: LLMConfig) -> BaseChatModel:
     from langchain_anthropic import ChatAnthropic
 
     api_key = _ensure_api_key(config, "ANTHROPIC_API_KEY")
@@ -47,7 +47,7 @@ def _create_anthropic_model(config: LLMProfileConfig) -> BaseChatModel:
     )
 
 
-def _create_google_model(config: LLMProfileConfig) -> BaseChatModel:
+def _create_google_model(config: LLMConfig) -> BaseChatModel:
     from langchain_google_genai import ChatGoogleGenerativeAI
 
     api_key = _ensure_api_key(config, "GOOGLE_API_KEY")
@@ -59,7 +59,7 @@ def _create_google_model(config: LLMProfileConfig) -> BaseChatModel:
     )
 
 
-def get_chat_model(config: LLMProfileConfig) -> BaseChatModel:
+def get_chat_model(config: LLMConfig) -> BaseChatModel:
     """
     Create a configured LangChain chat model for the given profile.
 

--- a/src/llm/factory.py
+++ b/src/llm/factory.py
@@ -95,19 +95,3 @@ def get_chat_model(config: LLMProfileConfig) -> BaseChatModel:
         ) from e
     except Exception as e:
         raise LLMProviderError(f"Failed to create chat model for provider '{provider}': {e}") from e
-
-
-def get_chat_model_by_profile_name(profile_name: str) -> BaseChatModel:
-    """
-    Create a LangChain chat model by configuration profile name.
-
-    Args:
-        profile_name: Name of the LLM profile in the configuration
-
-    Returns:
-        A LangChain BaseChatModel instance
-    """
-    from src.config import config
-
-    profile = config.get_llm_profile(profile_name)
-    return get_chat_model(profile)

--- a/tests/unit/config/test_system.py
+++ b/tests/unit/config/test_system.py
@@ -19,6 +19,38 @@ from src.exceptions.config import (
 )
 from src.models.enums import Environment
 
+# Full set of agent LLM configs required by AppConfig.agents.
+# Uses a "stage-test-model" name so model validation is skipped, and the
+# anthropic provider so the local ANTHROPIC_API_KEY (from .env) satisfies
+# api-key validation when a fixture runs under the dev environment.
+AGENTS_TOML = """
+[agents.job_evaluation_extraction]
+provider = "anthropic"
+model = "stage-test-model"
+temperature = 0.0
+max_tokens = 100
+
+[agents.job_evaluation_fit]
+provider = "anthropic"
+model = "stage-test-model"
+
+[agents.interview_research]
+provider = "anthropic"
+model = "stage-test-model"
+
+[agents.interview_question_generation]
+provider = "anthropic"
+model = "stage-test-model"
+
+[agents.interview_answer_generation]
+provider = "anthropic"
+model = "stage-test-model"
+
+[agents.interview_compilation]
+provider = "anthropic"
+model = "stage-test-model"
+"""
+
 
 class TestConfigLoader:
     """Test the ConfigLoader class."""
@@ -27,7 +59,8 @@ class TestConfigLoader:
         """Test loading development configuration."""
         # Create test config files
         base_config = tmp_path / "base.toml"
-        base_config.write_text("""
+        base_config.write_text(
+            """
 [general]
 name = "test-app"
 tagline = "Test dev application"
@@ -36,24 +69,13 @@ debug = false
 
 [logging]
 level = "INFO"
-
-[agents]
-job_evaluation_extraction = "test_profile"
-
-[evaluation_criteria]
-min_salary = 100000
-remote_required = true
-ic_title_requirements = ["senior"]
-
-[llm_profiles.test_profile]
-provider = "anthropic"
-model = "stage-test-model"
-temperature = 0.0
-max_tokens = 100
-
+"""
+            + AGENTS_TOML
+            + """
 [observability.langfuse]
 enabled = false
-""")
+"""
+        )
 
         dev_config = tmp_path / "dev.toml"
         dev_config.write_text("""
@@ -126,7 +148,8 @@ level = "DEBUG"
     def test_secrets_loading(self, tmp_path):
         """Test that secrets are loaded from environment variables."""
         base_config = tmp_path / "base.toml"
-        base_config.write_text("""
+        base_config.write_text(
+            """
 [general]
 name = "test"
 tagline = "Test secrets application"
@@ -134,22 +157,13 @@ version = "1.0.0"
 
 [logging]
 level = "INFO"
-
-[agents]
-job_evaluation_extraction = "anthropic_profile"
-
-[evaluation_criteria]
-min_salary = 100000
-remote_required = true
-ic_title_requirements = ["senior"]
-
-[llm_profiles.anthropic_profile]
-provider = "anthropic"
-model = "stage-test-model"
-
+"""
+            + AGENTS_TOML
+            + """
 [observability.langfuse]
 enabled = true
-""")
+"""
+        )
 
         dev_config = tmp_path / "dev.toml"
         dev_config.write_text("")
@@ -167,7 +181,7 @@ enabled = true
             raw_config = loader.load_raw_config()
 
             assert (
-                raw_config["llm_profiles"]["anthropic_profile"]["api_key"] == "test_anthropic_key"
+                raw_config["agents"]["job_evaluation_extraction"]["api_key"] == "test_anthropic_key"
             )
             assert raw_config["observability"]["langfuse"]["public_key"] == "test_public_key"
             assert raw_config["observability"]["langfuse"]["secret_key"] == "test_secret_key"
@@ -221,7 +235,8 @@ class TestConfigManager:
         """Test loading and validating configuration."""
         # Create minimal valid config
         base_config = tmp_path / "base.toml"
-        base_config.write_text("""
+        base_config.write_text(
+            """
 [general]
 name = "test-app"
 tagline = "Test application"
@@ -229,22 +244,13 @@ version = "1.0.0"
 
 [logging]
 level = "INFO"
-
-[agents]
-job_evaluation_extraction = "test_profile"
-
-[evaluation_criteria]
-min_salary = 100000
-remote_required = true
-ic_title_requirements = ["senior"]
-
-[llm_profiles.test_profile]
-provider = "anthropic"
-model = "stage-test-model"
-
+"""
+            + AGENTS_TOML
+            + """
 [observability.langfuse]
 enabled = false
-""")
+"""
+        )
 
         stage_config = tmp_path / "stage.toml"
         stage_config.write_text("")
@@ -259,7 +265,8 @@ enabled = false
     def test_singleton_behavior(self, tmp_path):
         """Test that ConfigManager follows singleton pattern."""
         base_config = tmp_path / "base.toml"
-        base_config.write_text("""
+        base_config.write_text(
+            """
 [general]
 name = "test-app"
 tagline = "Test application"
@@ -267,22 +274,13 @@ version = "1.0.0"
 
 [logging]
 level = "INFO"
-
-[agents]
-job_evaluation_extraction = "test_profile"
-
-[evaluation_criteria]
-min_salary = 100000
-remote_required = true
-ic_title_requirements = ["senior"]
-
-[llm_profiles.test_profile]
-provider = "anthropic"
-model = "stage-test-model"
-
+"""
+            + AGENTS_TOML
+            + """
 [observability.langfuse]
 enabled = false
-""")
+"""
+        )
 
         dev_config = tmp_path / "dev.toml"
         dev_config.write_text("")
@@ -302,7 +300,8 @@ enabled = false
         """Test that configuration can be reloaded."""
         # Create initial config
         base_config = tmp_path / "base.toml"
-        base_config.write_text("""
+        base_config.write_text(
+            """
 [general]
 name = "original-app"
 tagline = "Original application"
@@ -310,22 +309,13 @@ version = "1.0.0"
 
 [logging]
 level = "INFO"
-
-[agents]
-job_evaluation_extraction = "test_profile"
-
-[evaluation_criteria]
-min_salary = 100000
-remote_required = true
-ic_title_requirements = ["senior"]
-
-[llm_profiles.test_profile]
-provider = "anthropic"
-model = "stage-test-model"
-
+"""
+            + AGENTS_TOML
+            + """
 [observability.langfuse]
 enabled = false
-""")
+"""
+        )
 
         stage_config = tmp_path / "stage.toml"
         stage_config.write_text("")
@@ -337,7 +327,8 @@ enabled = false
             assert initial_config.general.name == "original-app"
 
             # Modify the config file
-            base_config.write_text("""
+            base_config.write_text(
+                """
 [general]
 name = "updated-app"
 tagline = "Updated application"
@@ -345,22 +336,13 @@ version = "1.0.0"
 
 [logging]
 level = "INFO"
-
-[agents]
-job_evaluation_extraction = "test_profile"
-
-[evaluation_criteria]
-min_salary = 100000
-remote_required = true
-ic_title_requirements = ["senior"]
-
-[llm_profiles.test_profile]
-provider = "anthropic"
-model = "stage-test-model"
-
+"""
+                + AGENTS_TOML
+                + """
 [observability.langfuse]
 enabled = false
-""")
+"""
+            )
 
             # Reload and verify change
             reloaded_config = manager.reload()
@@ -392,7 +374,8 @@ class TestLazyConfigProxy:
         """Test that config attributes are accessible via lazy proxy."""
         # Create test config
         base_config = tmp_path / "base.toml"
-        base_config.write_text("""
+        base_config.write_text(
+            """
 [general]
 name = "proxy-test"
 tagline = "Proxy test application"
@@ -400,22 +383,13 @@ version = "1.0.0"
 
 [logging]
 level = "DEBUG"
-
-[agents]
-job_evaluation_extraction = "test_profile"
-
-[evaluation_criteria]
-min_salary = 150000
-remote_required = false
-ic_title_requirements = ["staff", "principal"]
-
-[llm_profiles.test_profile]
-provider = "anthropic"
-model = "stage-test-model"
-
+"""
+            + AGENTS_TOML
+            + """
 [observability.langfuse]
 enabled = true
-""")
+"""
+        )
 
         stage_config = tmp_path / "stage.toml"
         stage_config.write_text("")
@@ -435,7 +409,8 @@ enabled = true
         """Test that proxy reload works correctly."""
         # Create initial config
         base_config = tmp_path / "base.toml"
-        base_config.write_text("""
+        base_config.write_text(
+            """
 [general]
 name = "initial"
 tagline = "Initial application"
@@ -443,22 +418,13 @@ version = "1.0.0"
 
 [logging]
 level = "INFO"
-
-[agents]
-job_evaluation_extraction = "test_profile"
-
-[evaluation_criteria]
-min_salary = 100000
-remote_required = true
-ic_title_requirements = ["senior"]
-
-[llm_profiles.test_profile]
-provider = "anthropic"
-model = "stage-test-model"
-
+"""
+            + AGENTS_TOML
+            + """
 [observability.langfuse]
 enabled = false
-""")
+"""
+        )
 
         stage_config = tmp_path / "stage.toml"
         stage_config.write_text("")
@@ -471,7 +437,8 @@ enabled = false
             assert test_config.general.name == "initial"
 
             # Modify config file
-            base_config.write_text("""
+            base_config.write_text(
+                """
 [general]
 name = "modified"
 tagline = "Modified application"
@@ -479,22 +446,13 @@ version = "1.0.0"
 
 [logging]
 level = "INFO"
-
-[agents]
-job_evaluation_extraction = "test_profile"
-
-[evaluation_criteria]
-min_salary = 100000
-remote_required = true
-ic_title_requirements = ["senior"]
-
-[llm_profiles.test_profile]
-provider = "anthropic"
-model = "stage-test-model"
-
+"""
+                + AGENTS_TOML
+                + """
 [observability.langfuse]
 enabled = false
-""")
+"""
+            )
 
             # Reload and verify
             test_config.reload(config_dir=tmp_path)
@@ -506,7 +464,7 @@ class TestConfigIntegration:
 
     def test_end_to_end_config_loading(self, tmp_path):
         """Test complete end-to-end configuration loading."""
-        # Create comprehensive config
+        # Create comprehensive config where each task directly defines its LLM
         base_config = tmp_path / "base.toml"
         base_config.write_text("""
 [general]
@@ -519,15 +477,37 @@ debug = false
 level = "INFO"
 format = "%(asctime)s %(name)s [%(levelname)s] %(message)s"
 
-[agents]
-job_evaluation_extraction = "claude_profile"
+[agents.job_evaluation_extraction]
+provider = "anthropic"
+model = "claude-haiku-4-5"
+temperature = 0.1
+max_tokens = 2048
 
-[evaluation_criteria]
-min_salary = 150000
-remote_required = true
-ic_title_requirements = ["senior", "staff", "principal"]
+[agents.job_evaluation_fit]
+provider = "anthropic"
+model = "claude-haiku-4-5"
+temperature = 0.1
+max_tokens = 2048
 
-[llm_profiles.claude_profile]
+[agents.interview_research]
+provider = "anthropic"
+model = "claude-haiku-4-5"
+temperature = 0.1
+max_tokens = 2048
+
+[agents.interview_question_generation]
+provider = "anthropic"
+model = "claude-haiku-4-5"
+temperature = 0.1
+max_tokens = 2048
+
+[agents.interview_answer_generation]
+provider = "anthropic"
+model = "claude-haiku-4-5"
+temperature = 0.1
+max_tokens = 2048
+
+[agents.interview_compilation]
 provider = "anthropic"
 model = "claude-haiku-4-5"
 temperature = 0.1
@@ -546,7 +526,7 @@ debug = true
 [logging]
 level = "DEBUG"
 
-[llm_profiles.claude_profile]
+[agents.job_evaluation_extraction]
 temperature = 0.0
 """)
 
@@ -567,13 +547,15 @@ temperature = 0.0
             assert settings.general.name == "integration-test"
             assert settings.general.debug is True  # Overridden by dev.toml
             assert settings.logging.level == "DEBUG"  # Overridden by dev.toml
-            assert settings.llm_profiles["claude_profile"].temperature == 0.0  # Overridden
-            assert settings.llm_profiles["claude_profile"].api_key == "test-key"  # From env
+
+            # Per-task LLM config, with a surgical override applied to one task
+            extraction = settings.agents.job_evaluation_extraction
+            assert extraction.temperature == 0.0  # Overridden by dev.toml
+            assert extraction.api_key == "test-key"  # From env
+            assert extraction.provider == "anthropic"
+            assert extraction.model == "claude-haiku-4-5"
+
+            # Other tasks keep the base temperature (override was surgical)
+            assert settings.agents.interview_research.temperature == 0.1
+
             assert settings.observability.langfuse.public_key == "test-public"  # From env
-
-            # Test model methods
-            profile = settings.get_llm_profile("claude_profile")
-            assert profile.provider == "anthropic"
-
-            agent_profile = settings.get_agent_llm_profile("job_evaluation_extraction")
-            assert agent_profile.model == "claude-haiku-4-5"

--- a/tests/unit/config/test_system.py
+++ b/tests/unit/config/test_system.py
@@ -19,34 +19,34 @@ from src.exceptions.config import (
 )
 from src.models.enums import Environment
 
-# Full set of agent LLM configs required by AppConfig.agents.
+# Full set of agent task LLM configs required by AppConfig.agent_tasks.
 # Uses a "stage-test-model" name so model validation is skipped, and the
 # anthropic provider so the local ANTHROPIC_API_KEY (from .env) satisfies
 # api-key validation when a fixture runs under the dev environment.
-AGENTS_TOML = """
-[agents.job_evaluation_extraction]
+AGENT_TASKS_TOML = """
+[agent_tasks.job_evaluation_extraction]
 provider = "anthropic"
 model = "stage-test-model"
 temperature = 0.0
 max_tokens = 100
 
-[agents.job_evaluation_fit]
+[agent_tasks.job_evaluation_fit]
 provider = "anthropic"
 model = "stage-test-model"
 
-[agents.interview_research]
+[agent_tasks.interview_research]
 provider = "anthropic"
 model = "stage-test-model"
 
-[agents.interview_question_generation]
+[agent_tasks.interview_question_generation]
 provider = "anthropic"
 model = "stage-test-model"
 
-[agents.interview_answer_generation]
+[agent_tasks.interview_answer_generation]
 provider = "anthropic"
 model = "stage-test-model"
 
-[agents.interview_compilation]
+[agent_tasks.interview_compilation]
 provider = "anthropic"
 model = "stage-test-model"
 """
@@ -70,7 +70,7 @@ debug = false
 [logging]
 level = "INFO"
 """
-            + AGENTS_TOML
+            + AGENT_TASKS_TOML
             + """
 [observability.langfuse]
 enabled = false
@@ -158,7 +158,7 @@ version = "1.0.0"
 [logging]
 level = "INFO"
 """
-            + AGENTS_TOML
+            + AGENT_TASKS_TOML
             + """
 [observability.langfuse]
 enabled = true
@@ -181,7 +181,8 @@ enabled = true
             raw_config = loader.load_raw_config()
 
             assert (
-                raw_config["agents"]["job_evaluation_extraction"]["api_key"] == "test_anthropic_key"
+                raw_config["agent_tasks"]["job_evaluation_extraction"]["api_key"]
+                == "test_anthropic_key"
             )
             assert raw_config["observability"]["langfuse"]["public_key"] == "test_public_key"
             assert raw_config["observability"]["langfuse"]["secret_key"] == "test_secret_key"
@@ -245,7 +246,7 @@ version = "1.0.0"
 [logging]
 level = "INFO"
 """
-            + AGENTS_TOML
+            + AGENT_TASKS_TOML
             + """
 [observability.langfuse]
 enabled = false
@@ -275,7 +276,7 @@ version = "1.0.0"
 [logging]
 level = "INFO"
 """
-            + AGENTS_TOML
+            + AGENT_TASKS_TOML
             + """
 [observability.langfuse]
 enabled = false
@@ -310,7 +311,7 @@ version = "1.0.0"
 [logging]
 level = "INFO"
 """
-            + AGENTS_TOML
+            + AGENT_TASKS_TOML
             + """
 [observability.langfuse]
 enabled = false
@@ -337,7 +338,7 @@ version = "1.0.0"
 [logging]
 level = "INFO"
 """
-                + AGENTS_TOML
+                + AGENT_TASKS_TOML
                 + """
 [observability.langfuse]
 enabled = false
@@ -384,7 +385,7 @@ version = "1.0.0"
 [logging]
 level = "DEBUG"
 """
-            + AGENTS_TOML
+            + AGENT_TASKS_TOML
             + """
 [observability.langfuse]
 enabled = true
@@ -419,7 +420,7 @@ version = "1.0.0"
 [logging]
 level = "INFO"
 """
-            + AGENTS_TOML
+            + AGENT_TASKS_TOML
             + """
 [observability.langfuse]
 enabled = false
@@ -447,7 +448,7 @@ version = "1.0.0"
 [logging]
 level = "INFO"
 """
-                + AGENTS_TOML
+                + AGENT_TASKS_TOML
                 + """
 [observability.langfuse]
 enabled = false
@@ -477,37 +478,37 @@ debug = false
 level = "INFO"
 format = "%(asctime)s %(name)s [%(levelname)s] %(message)s"
 
-[agents.job_evaluation_extraction]
+[agent_tasks.job_evaluation_extraction]
 provider = "anthropic"
 model = "claude-haiku-4-5"
 temperature = 0.1
 max_tokens = 2048
 
-[agents.job_evaluation_fit]
+[agent_tasks.job_evaluation_fit]
 provider = "anthropic"
 model = "claude-haiku-4-5"
 temperature = 0.1
 max_tokens = 2048
 
-[agents.interview_research]
+[agent_tasks.interview_research]
 provider = "anthropic"
 model = "claude-haiku-4-5"
 temperature = 0.1
 max_tokens = 2048
 
-[agents.interview_question_generation]
+[agent_tasks.interview_question_generation]
 provider = "anthropic"
 model = "claude-haiku-4-5"
 temperature = 0.1
 max_tokens = 2048
 
-[agents.interview_answer_generation]
+[agent_tasks.interview_answer_generation]
 provider = "anthropic"
 model = "claude-haiku-4-5"
 temperature = 0.1
 max_tokens = 2048
 
-[agents.interview_compilation]
+[agent_tasks.interview_compilation]
 provider = "anthropic"
 model = "claude-haiku-4-5"
 temperature = 0.1
@@ -526,7 +527,7 @@ debug = true
 [logging]
 level = "DEBUG"
 
-[agents.job_evaluation_extraction]
+[agent_tasks.job_evaluation_extraction]
 temperature = 0.0
 """)
 
@@ -549,13 +550,13 @@ temperature = 0.0
             assert settings.logging.level == "DEBUG"  # Overridden by dev.toml
 
             # Per-task LLM config, with a surgical override applied to one task
-            extraction = settings.agents.job_evaluation_extraction
+            extraction = settings.agent_tasks.job_evaluation_extraction
             assert extraction.temperature == 0.0  # Overridden by dev.toml
             assert extraction.api_key == "test-key"  # From env
             assert extraction.provider == "anthropic"
             assert extraction.model == "claude-haiku-4-5"
 
             # Other tasks keep the base temperature (override was surgical)
-            assert settings.agents.interview_research.temperature == 0.1
+            assert settings.agent_tasks.interview_research.temperature == 0.1
 
             assert settings.observability.langfuse.public_key == "test-public"  # From env

--- a/tests/unit/core/job_evaluation/test_fit_evaluator.py
+++ b/tests/unit/core/job_evaluation/test_fit_evaluator.py
@@ -23,7 +23,7 @@ class TestEvaluateFit:
         result = evaluate_fit("some job text", prefs)
         assert result["pass"] is False
 
-    @patch("src.core.job_evaluation.fit_evaluator.get_chat_model_by_profile_name")
+    @patch("src.core.job_evaluation.fit_evaluator.get_chat_model")
     def test_good_fit_passes(self, mock_get_model):
         structured = Mock()
         structured.invoke.return_value = FitAssessment(
@@ -42,7 +42,7 @@ class TestEvaluateFit:
         assert result["pass"] is True
         assert result["extracted_value"] == "good_fit"
 
-    @patch("src.core.job_evaluation.fit_evaluator.get_chat_model_by_profile_name")
+    @patch("src.core.job_evaluation.fit_evaluator.get_chat_model")
     def test_poor_fit_fails(self, mock_get_model):
         structured = Mock()
         structured.invoke.return_value = FitAssessment(
@@ -58,7 +58,7 @@ class TestEvaluateFit:
         assert result["pass"] is False
         assert result["extracted_value"] == "poor_fit"
 
-    @patch("src.core.job_evaluation.fit_evaluator.get_chat_model_by_profile_name")
+    @patch("src.core.job_evaluation.fit_evaluator.get_chat_model")
     def test_llm_failure_falls_back_to_none_policy(self, mock_get_model):
         """A transient LLM failure must not raise; it returns a graceful result."""
         structured = Mock()
@@ -75,7 +75,7 @@ class TestEvaluateFit:
         assert "Fit assessment failed" in result["reason"]
         assert result["extracted_value"] is None
 
-    @patch("src.core.job_evaluation.fit_evaluator.get_chat_model_by_profile_name")
+    @patch("src.core.job_evaluation.fit_evaluator.get_chat_model")
     def test_llm_failure_with_fail_none_policy(self, mock_get_model):
         structured = Mock()
         structured.invoke.side_effect = RuntimeError("boom")
@@ -90,7 +90,7 @@ class TestEvaluateFit:
         assert result["pass"] is False
         assert "Fit assessment failed" in result["reason"]
 
-    @patch("src.core.job_evaluation.fit_evaluator.get_chat_model_by_profile_name")
+    @patch("src.core.job_evaluation.fit_evaluator.get_chat_model")
     def test_model_construction_failure_does_not_raise(self, mock_get_model):
         """A failure before the LLM call (e.g. provider ImportError) is caught too."""
         mock_get_model.side_effect = ImportError("provider package missing")

--- a/tests/unit/integration/test_api_key_validation.py
+++ b/tests/unit/integration/test_api_key_validation.py
@@ -9,7 +9,7 @@ import os
 
 import pytest
 
-from src.config.models import LLMProfileConfig
+from src.config.models import LLMConfig
 from src.exceptions.llm import LLMProviderError
 from src.llm import get_chat_model
 
@@ -19,7 +19,7 @@ class TestAPIKeyValidation:
 
     def test_anthropic_missing_api_key_raises_error(self):
         """Test that Anthropic model creation fails without API key."""
-        config = LLMProfileConfig(
+        config = LLMConfig(
             provider="anthropic",
             model="claude-haiku-4-5",
         )
@@ -35,7 +35,7 @@ class TestAPIKeyValidation:
 
     def test_anthropic_accepts_valid_api_key(self):
         """Test that Anthropic model is created with a valid API key."""
-        config = LLMProfileConfig(
+        config = LLMConfig(
             provider="anthropic",
             model="claude-haiku-4-5",
             api_key="sk-ant-api03-test-key-format",
@@ -47,12 +47,12 @@ class TestAPIKeyValidation:
     def test_different_providers_require_different_api_keys(self):
         """Test that different providers validate their specific API key
         environment variables."""
-        anthropic_config = LLMProfileConfig(
+        anthropic_config = LLMConfig(
             provider="anthropic",
             model="claude-haiku-4-5",
         )
 
-        google_config = LLMProfileConfig(
+        google_config = LLMConfig(
             provider="google",
             model="gemini-2.5-flash",
         )
@@ -81,7 +81,7 @@ class TestAPIKeyValidation:
         os.environ["ANTHROPIC_API_KEY"] = env_key
 
         try:
-            config = LLMProfileConfig(
+            config = LLMConfig(
                 provider="anthropic",
                 model="claude-haiku-4-5",
                 api_key=config_key,

--- a/tests/unit/integration/test_environment_check.py
+++ b/tests/unit/integration/test_environment_check.py
@@ -5,28 +5,28 @@ Tests for environment check component functionality
 from typing import Optional
 from unittest.mock import MagicMock, patch
 
-from src.config.models import AgentTasksConfig, LLMProfileConfig
+from src.config.models import AgentTasksConfig, LLMConfig
 from ui.components.environment_check import (
     build_setup_instructions,
     check_environment_setup,
 )
 
 
-def _make_profile(provider: str, api_key: Optional[str]) -> LLMProfileConfig:
-    """Build a profile for tests. APP_ENV=stage in conftest.py disables
+def _make_llm_config(provider: str, api_key: Optional[str]) -> LLMConfig:
+    """Build an LLMConfig for tests. APP_ENV=stage in conftest.py disables
     model/api-key validators so api_key=None is allowed here."""
-    return LLMProfileConfig(
+    return LLMConfig(
         provider=provider,
         model="stage-test-model",
         api_key=api_key,
     )
 
 
-def _make_agent_tasks(**overrides: LLMProfileConfig) -> AgentTasksConfig:
+def _make_agent_tasks(**overrides: LLMConfig) -> AgentTasksConfig:
     """Build a real AgentTasksConfig. Defaults to anthropic+valid key for
     every task; tests override only the tasks they care about so a real
     Pydantic model is exercised in every code path."""
-    default = _make_profile("anthropic", "default-key")
+    default = _make_llm_config("anthropic", "default-key")
     fields = {
         "job_evaluation_extraction": default,
         "job_evaluation_fit": default,
@@ -57,7 +57,7 @@ class TestEnvironmentCheck:
         """One task missing its api_key → that provider's env var is reported"""
         mock_config = MagicMock()
         mock_config.agent_tasks = _make_agent_tasks(
-            job_evaluation_extraction=_make_profile("anthropic", None),
+            job_evaluation_extraction=_make_llm_config("anthropic", None),
         )
 
         with patch("ui.components.environment_check.config", mock_config):
@@ -70,8 +70,8 @@ class TestEnvironmentCheck:
         """Tasks missing keys for different providers → all are reported"""
         mock_config = MagicMock()
         mock_config.agent_tasks = _make_agent_tasks(
-            job_evaluation_extraction=_make_profile("anthropic", None),
-            interview_research=_make_profile("google", None),
+            job_evaluation_extraction=_make_llm_config("anthropic", None),
+            interview_research=_make_llm_config("google", None),
         )
 
         with patch("ui.components.environment_check.config", mock_config):
@@ -86,8 +86,8 @@ class TestEnvironmentCheck:
         """Multiple tasks sharing one provider → env var is reported once"""
         mock_config = MagicMock()
         mock_config.agent_tasks = _make_agent_tasks(
-            interview_research=_make_profile("google", None),
-            interview_compilation=_make_profile("google", None),
+            interview_research=_make_llm_config("google", None),
+            interview_compilation=_make_llm_config("google", None),
         )
 
         with patch("ui.components.environment_check.config", mock_config):

--- a/tests/unit/integration/test_environment_check.py
+++ b/tests/unit/integration/test_environment_check.py
@@ -2,6 +2,7 @@
 Tests for environment check component functionality
 """
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from ui.components.environment_check import check_environment_setup
@@ -16,7 +17,7 @@ class TestEnvironmentCheck:
         mock_config = MagicMock()
         mock_profile = MagicMock()
         mock_profile.api_key = "test-key"
-        mock_config.llm_profiles.items.return_value = [("test_profile", mock_profile)]
+        mock_config.agents = SimpleNamespace(job_evaluation_extraction=mock_profile)
 
         with patch("ui.components.environment_check.config", mock_config):
             is_valid, message = check_environment_setup()
@@ -31,7 +32,7 @@ class TestEnvironmentCheck:
         mock_profile = MagicMock()
         mock_profile.api_key = None
         mock_profile.provider = "anthropic"
-        mock_config.llm_profiles.items.return_value = [("test_profile", mock_profile)]
+        mock_config.agents = SimpleNamespace(job_evaluation_extraction=mock_profile)
 
         with patch("ui.components.environment_check.config", mock_config):
             is_valid, message = check_environment_setup()
@@ -41,7 +42,7 @@ class TestEnvironmentCheck:
 
     def test_environment_check_with_multiple_missing_keys(self):
         """Test environment check with multiple missing API keys"""
-        # Mock config with multiple profiles missing API keys
+        # Mock config with multiple tasks missing API keys for different providers
         mock_config = MagicMock()
 
         mock_profile1 = MagicMock()
@@ -50,12 +51,12 @@ class TestEnvironmentCheck:
 
         mock_profile2 = MagicMock()
         mock_profile2.api_key = None
-        mock_profile2.provider = "fireworks"
+        mock_profile2.provider = "google"
 
-        mock_config.llm_profiles.items.return_value = [
-            ("anthropic_profile", mock_profile1),
-            ("fireworks_profile", mock_profile2),
-        ]
+        mock_config.agents = SimpleNamespace(
+            job_evaluation_extraction=mock_profile1,
+            interview_research=mock_profile2,
+        )
 
         with patch("ui.components.environment_check.config", mock_config):
             is_valid, message = check_environment_setup()
@@ -63,15 +64,41 @@ class TestEnvironmentCheck:
             assert is_valid is False
             assert "Missing required API keys:" in message
             assert "ANTHROPIC_API_KEY" in message
-            assert "FIREWORKS_API_KEY" in message
+            assert "GOOGLE_API_KEY" in message
+
+    def test_environment_check_deduplicates_shared_provider(self):
+        """Test that a provider shared by multiple tasks is reported once"""
+        mock_config = MagicMock()
+
+        mock_profile1 = MagicMock()
+        mock_profile1.api_key = None
+        mock_profile1.provider = "google"
+
+        mock_profile2 = MagicMock()
+        mock_profile2.api_key = None
+        mock_profile2.provider = "google"
+
+        mock_config.agents = SimpleNamespace(
+            interview_research=mock_profile1,
+            interview_compilation=mock_profile2,
+        )
+
+        with patch("ui.components.environment_check.config", mock_config):
+            is_valid, message = check_environment_setup()
+
+            assert is_valid is False
+            assert message.count("GOOGLE_API_KEY") == 1
 
     def test_environment_check_handles_config_errors(self):
         """Test that environment check handles configuration errors gracefully"""
-        # Mock config that raises an exception
-        mock_config = MagicMock()
-        mock_config.llm_profiles.items.side_effect = Exception("Config error")
 
-        with patch("ui.components.environment_check.config", mock_config):
+        # Config object whose agents access raises an exception
+        class BadConfig:
+            @property
+            def agents(self):
+                raise Exception("Config error")
+
+        with patch("ui.components.environment_check.config", BadConfig()):
             is_valid, message = check_environment_setup()
 
             assert is_valid is False

--- a/tests/unit/integration/test_environment_check.py
+++ b/tests/unit/integration/test_environment_check.py
@@ -17,7 +17,7 @@ class TestEnvironmentCheck:
         mock_config = MagicMock()
         mock_profile = MagicMock()
         mock_profile.api_key = "test-key"
-        mock_config.agents = SimpleNamespace(job_evaluation_extraction=mock_profile)
+        mock_config.agent_tasks = SimpleNamespace(job_evaluation_extraction=mock_profile)
 
         with patch("ui.components.environment_check.config", mock_config):
             is_valid, message = check_environment_setup()
@@ -32,7 +32,7 @@ class TestEnvironmentCheck:
         mock_profile = MagicMock()
         mock_profile.api_key = None
         mock_profile.provider = "anthropic"
-        mock_config.agents = SimpleNamespace(job_evaluation_extraction=mock_profile)
+        mock_config.agent_tasks = SimpleNamespace(job_evaluation_extraction=mock_profile)
 
         with patch("ui.components.environment_check.config", mock_config):
             is_valid, message = check_environment_setup()
@@ -53,7 +53,7 @@ class TestEnvironmentCheck:
         mock_profile2.api_key = None
         mock_profile2.provider = "google"
 
-        mock_config.agents = SimpleNamespace(
+        mock_config.agent_tasks = SimpleNamespace(
             job_evaluation_extraction=mock_profile1,
             interview_research=mock_profile2,
         )
@@ -78,7 +78,7 @@ class TestEnvironmentCheck:
         mock_profile2.api_key = None
         mock_profile2.provider = "google"
 
-        mock_config.agents = SimpleNamespace(
+        mock_config.agent_tasks = SimpleNamespace(
             interview_research=mock_profile1,
             interview_compilation=mock_profile2,
         )
@@ -92,10 +92,10 @@ class TestEnvironmentCheck:
     def test_environment_check_handles_config_errors(self):
         """Test that environment check handles configuration errors gracefully"""
 
-        # Config object whose agents access raises an exception
+        # Config object whose agent_tasks access raises an exception
         class BadConfig:
             @property
-            def agents(self):
+            def agent_tasks(self):
                 raise Exception("Config error")
 
         with patch("ui.components.environment_check.config", BadConfig()):

--- a/tests/unit/integration/test_environment_check.py
+++ b/tests/unit/integration/test_environment_check.py
@@ -2,25 +2,50 @@
 Tests for environment check component functionality
 """
 
-from types import SimpleNamespace
+from typing import Optional
 from unittest.mock import MagicMock, patch
 
+from src.config.models import AgentTasksConfig, LLMProfileConfig
 from ui.components.environment_check import (
     build_setup_instructions,
     check_environment_setup,
 )
 
 
+def _make_profile(provider: str, api_key: Optional[str]) -> LLMProfileConfig:
+    """Build a profile for tests. APP_ENV=stage in conftest.py disables
+    model/api-key validators so api_key=None is allowed here."""
+    return LLMProfileConfig(
+        provider=provider,
+        model="stage-test-model",
+        api_key=api_key,
+    )
+
+
+def _make_agent_tasks(**overrides: LLMProfileConfig) -> AgentTasksConfig:
+    """Build a real AgentTasksConfig. Defaults to anthropic+valid key for
+    every task; tests override only the tasks they care about so a real
+    Pydantic model is exercised in every code path."""
+    default = _make_profile("anthropic", "default-key")
+    fields = {
+        "job_evaluation_extraction": default,
+        "job_evaluation_fit": default,
+        "interview_research": default,
+        "interview_question_generation": default,
+        "interview_answer_generation": default,
+        "interview_compilation": default,
+    }
+    fields.update(overrides)
+    return AgentTasksConfig(**fields)
+
+
 class TestEnvironmentCheck:
     """Test environment check functionality"""
 
     def test_environment_check_with_valid_api_keys(self):
-        """Test that environment check passes when API keys are present"""
-        # Mock config with valid API keys
+        """All tasks have api_key set → environment reports as valid"""
         mock_config = MagicMock()
-        mock_profile = MagicMock()
-        mock_profile.api_key = "test-key"
-        mock_config.agent_tasks = SimpleNamespace(job_evaluation_extraction=mock_profile)
+        mock_config.agent_tasks = _make_agent_tasks()
 
         with patch("ui.components.environment_check.config", mock_config):
             is_valid, message = check_environment_setup()
@@ -29,13 +54,11 @@ class TestEnvironmentCheck:
             assert message == "Environment is properly configured"
 
     def test_environment_check_with_missing_api_keys(self):
-        """Test that environment check fails when API keys are missing"""
-        # Mock config with missing API keys
+        """One task missing its api_key → that provider's env var is reported"""
         mock_config = MagicMock()
-        mock_profile = MagicMock()
-        mock_profile.api_key = None
-        mock_profile.provider = "anthropic"
-        mock_config.agent_tasks = SimpleNamespace(job_evaluation_extraction=mock_profile)
+        mock_config.agent_tasks = _make_agent_tasks(
+            job_evaluation_extraction=_make_profile("anthropic", None),
+        )
 
         with patch("ui.components.environment_check.config", mock_config):
             is_valid, message = check_environment_setup()
@@ -44,21 +67,11 @@ class TestEnvironmentCheck:
             assert "Missing required API keys: ANTHROPIC_API_KEY" in message
 
     def test_environment_check_with_multiple_missing_keys(self):
-        """Test environment check with multiple missing API keys"""
-        # Mock config with multiple tasks missing API keys for different providers
+        """Tasks missing keys for different providers → all are reported"""
         mock_config = MagicMock()
-
-        mock_profile1 = MagicMock()
-        mock_profile1.api_key = None
-        mock_profile1.provider = "anthropic"
-
-        mock_profile2 = MagicMock()
-        mock_profile2.api_key = None
-        mock_profile2.provider = "google"
-
-        mock_config.agent_tasks = SimpleNamespace(
-            job_evaluation_extraction=mock_profile1,
-            interview_research=mock_profile2,
+        mock_config.agent_tasks = _make_agent_tasks(
+            job_evaluation_extraction=_make_profile("anthropic", None),
+            interview_research=_make_profile("google", None),
         )
 
         with patch("ui.components.environment_check.config", mock_config):
@@ -70,20 +83,11 @@ class TestEnvironmentCheck:
             assert "GOOGLE_API_KEY" in message
 
     def test_environment_check_deduplicates_shared_provider(self):
-        """Test that a provider shared by multiple tasks is reported once"""
+        """Multiple tasks sharing one provider → env var is reported once"""
         mock_config = MagicMock()
-
-        mock_profile1 = MagicMock()
-        mock_profile1.api_key = None
-        mock_profile1.provider = "google"
-
-        mock_profile2 = MagicMock()
-        mock_profile2.api_key = None
-        mock_profile2.provider = "google"
-
-        mock_config.agent_tasks = SimpleNamespace(
-            interview_research=mock_profile1,
-            interview_compilation=mock_profile2,
+        mock_config.agent_tasks = _make_agent_tasks(
+            interview_research=_make_profile("google", None),
+            interview_compilation=_make_profile("google", None),
         )
 
         with patch("ui.components.environment_check.config", mock_config):

--- a/tests/unit/integration/test_environment_check.py
+++ b/tests/unit/integration/test_environment_check.py
@@ -5,7 +5,10 @@ Tests for environment check component functionality
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
-from ui.components.environment_check import check_environment_setup
+from ui.components.environment_check import (
+    build_setup_instructions,
+    check_environment_setup,
+)
 
 
 class TestEnvironmentCheck:
@@ -103,3 +106,37 @@ class TestEnvironmentCheck:
 
             assert is_valid is False
             assert "Configuration error: Config error" in message
+
+
+class TestBuildSetupInstructions:
+    """Test setup-instruction rendering stays in sync with detected
+    missing keys, so the UI does not contradict the warning banner."""
+
+    def test_instructions_reference_each_missing_key(self):
+        """When the detector reports a key, instructions must mention it."""
+        instructions = build_setup_instructions({"GOOGLE_API_KEY"})
+
+        assert "GOOGLE_API_KEY" in instructions
+        # And do not invent a different key the detector did not report
+        assert "ANTHROPIC_API_KEY" not in instructions
+
+    def test_instructions_list_multiple_missing_keys(self):
+        instructions = build_setup_instructions({"ANTHROPIC_API_KEY", "GOOGLE_API_KEY"})
+
+        assert "ANTHROPIC_API_KEY" in instructions
+        assert "GOOGLE_API_KEY" in instructions
+
+    def test_instructions_have_generic_fallback_when_no_keys_known(self):
+        """If the detector could not enumerate keys (e.g. config error),
+        instructions still render without naming the wrong provider."""
+        instructions = build_setup_instructions(set())
+
+        assert "ANTHROPIC_API_KEY" not in instructions
+        assert "GOOGLE_API_KEY" not in instructions
+        assert ".env" in instructions
+
+    def test_instructions_keep_langfuse_optional_section(self):
+        instructions = build_setup_instructions({"GOOGLE_API_KEY"})
+
+        assert "LANGFUSE_PUBLIC_KEY" in instructions
+        assert "LANGFUSE_SECRET_KEY" in instructions

--- a/tests/unit/llm/test_factory.py
+++ b/tests/unit/llm/test_factory.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from src.config.models import LLMProfileConfig
+from src.config.models import LLMConfig
 from src.exceptions.llm import LLMProviderError
 from src.llm.factory import (
     _ensure_api_key,
@@ -26,9 +26,7 @@ class TestGetChatModel:
         mock_model = MagicMock()
         mock_create.return_value = mock_model
 
-        config = LLMProfileConfig(
-            provider="anthropic", model="claude-haiku-4-5", api_key="test-key"
-        )
+        config = LLMConfig(provider="anthropic", model="claude-haiku-4-5", api_key="test-key")
 
         result = get_chat_model(config)
 
@@ -41,7 +39,7 @@ class TestGetChatModel:
         mock_model = MagicMock()
         mock_create.return_value = mock_model
 
-        config = LLMProfileConfig(provider="google", model="gemini-2.5-flash", api_key="test-key")
+        config = LLMConfig(provider="google", model="gemini-2.5-flash", api_key="test-key")
 
         result = get_chat_model(config)
 
@@ -50,9 +48,7 @@ class TestGetChatModel:
 
     def test_unsupported_provider_raises_error(self):
         """Test that unsupported provider raises LLMProviderError."""
-        config = LLMProfileConfig(
-            provider="anthropic", model="claude-haiku-4-5", api_key="test-key"
-        )
+        config = LLMConfig(provider="anthropic", model="claude-haiku-4-5", api_key="test-key")
         config.provider = "unsupported"
 
         with pytest.raises(LLMProviderError, match="Unsupported LLM provider"):
@@ -63,9 +59,7 @@ class TestGetChatModel:
         with patch("src.llm.factory._create_anthropic_model") as mock_create:
             mock_create.return_value = MagicMock()
 
-            config = LLMProfileConfig(
-                provider="ANTHROPIC", model="claude-haiku-4-5", api_key="test-key"
-            )
+            config = LLMConfig(provider="ANTHROPIC", model="claude-haiku-4-5", api_key="test-key")
 
             get_chat_model(config)
             mock_create.assert_called_once()
@@ -75,9 +69,7 @@ class TestGetChatModel:
         """Test that import errors are wrapped in LLMProviderError."""
         mock_create.side_effect = ImportError("langchain_anthropic not installed")
 
-        config = LLMProfileConfig(
-            provider="anthropic", model="claude-haiku-4-5", api_key="test-key"
-        )
+        config = LLMConfig(provider="anthropic", model="claude-haiku-4-5", api_key="test-key")
 
         with pytest.raises(LLMProviderError, match="Failed to import dependencies"):
             get_chat_model(config)
@@ -87,9 +79,7 @@ class TestGetChatModel:
         """Test that generic errors are wrapped in LLMProviderError."""
         mock_create.side_effect = RuntimeError("Connection failed")
 
-        config = LLMProfileConfig(
-            provider="anthropic", model="claude-haiku-4-5", api_key="test-key"
-        )
+        config = LLMConfig(provider="anthropic", model="claude-haiku-4-5", api_key="test-key")
 
         with pytest.raises(LLMProviderError, match="Failed to create chat model"):
             get_chat_model(config)
@@ -99,9 +89,7 @@ class TestGetChatModel:
         """Test that LLMProviderError from constructor passes through unwrapped."""
         mock_create.side_effect = LLMProviderError("API key not found")
 
-        config = LLMProfileConfig(
-            provider="anthropic", model="claude-haiku-4-5", api_key="test-key"
-        )
+        config = LLMConfig(provider="anthropic", model="claude-haiku-4-5", api_key="test-key")
 
         with pytest.raises(LLMProviderError, match="API key not found"):
             get_chat_model(config)
@@ -116,7 +104,7 @@ class TestProviderConstructors:
         mock_instance = MagicMock()
         mock_chat_class.return_value = mock_instance
 
-        config = LLMProfileConfig(
+        config = LLMConfig(
             provider="anthropic",
             model="claude-haiku-4-5",
             temperature=0.7,
@@ -142,7 +130,7 @@ class TestProviderConstructors:
         mock_instance = MagicMock()
         mock_chat_class.return_value = mock_instance
 
-        config = LLMProfileConfig(
+        config = LLMConfig(
             provider="google",
             model="gemini-2.5-flash",
             temperature=0.2,
@@ -168,9 +156,7 @@ class TestEnsureApiKey:
 
     def test_returns_key_from_config(self):
         """Test that API key from config is returned."""
-        config = LLMProfileConfig(
-            provider="anthropic", model="claude-haiku-4-5", api_key="config-key"
-        )
+        config = LLMConfig(provider="anthropic", model="claude-haiku-4-5", api_key="config-key")
 
         result = _ensure_api_key(config, "ANTHROPIC_API_KEY")
         assert result == "config-key"
@@ -178,7 +164,7 @@ class TestEnsureApiKey:
     @patch.dict("os.environ", {"TEST_KEY": "env-key"})
     def test_returns_key_from_environment(self):
         """Test that API key from environment is returned when config has none."""
-        config = LLMProfileConfig(provider="anthropic", model="claude-haiku-4-5")
+        config = LLMConfig(provider="anthropic", model="claude-haiku-4-5")
 
         result = _ensure_api_key(config, "TEST_KEY")
         assert result == "env-key"
@@ -186,9 +172,7 @@ class TestEnsureApiKey:
     @patch.dict("os.environ", {"TEST_KEY": "env-key"})
     def test_config_key_takes_precedence(self):
         """Test that config key takes precedence over environment."""
-        config = LLMProfileConfig(
-            provider="anthropic", model="claude-haiku-4-5", api_key="config-key"
-        )
+        config = LLMConfig(provider="anthropic", model="claude-haiku-4-5", api_key="config-key")
 
         result = _ensure_api_key(config, "TEST_KEY")
         assert result == "config-key"
@@ -196,7 +180,7 @@ class TestEnsureApiKey:
     @patch.dict("os.environ", {}, clear=True)
     def test_missing_key_raises_error(self):
         """Test that missing API key raises LLMProviderError."""
-        config = LLMProfileConfig(provider="anthropic", model="claude-haiku-4-5")
+        config = LLMConfig(provider="anthropic", model="claude-haiku-4-5")
 
         with pytest.raises(LLMProviderError, match="API key not found"):
             _ensure_api_key(config, "MISSING_KEY")
@@ -204,7 +188,7 @@ class TestEnsureApiKey:
     @patch.dict("os.environ", {}, clear=True)
     def test_error_message_contains_env_var_name(self):
         """Test that error message includes the environment variable name."""
-        config = LLMProfileConfig(provider="anthropic", model="claude-haiku-4-5")
+        config = LLMConfig(provider="anthropic", model="claude-haiku-4-5")
 
         with pytest.raises(LLMProviderError, match="MY_API_KEY"):
             _ensure_api_key(config, "MY_API_KEY")

--- a/tests/unit/llm/test_factory.py
+++ b/tests/unit/llm/test_factory.py
@@ -1,8 +1,8 @@
 """
 Unit tests for the LLM model factory.
 
-Tests get_chat_model and get_chat_model_by_profile_name functions
-including provider creation, error handling, and API key validation.
+Tests the get_chat_model function including provider creation, error
+handling, and API key validation.
 """
 
 from unittest.mock import MagicMock, patch
@@ -14,7 +14,6 @@ from src.exceptions.llm import LLMProviderError
 from src.llm.factory import (
     _ensure_api_key,
     get_chat_model,
-    get_chat_model_by_profile_name,
 )
 
 
@@ -106,27 +105,6 @@ class TestGetChatModel:
 
         with pytest.raises(LLMProviderError, match="API key not found"):
             get_chat_model(config)
-
-
-class TestGetChatModelByProfileName:
-    """Test the get_chat_model_by_profile_name function."""
-
-    @patch("src.llm.factory.get_chat_model")
-    @patch("src.config.config")
-    def test_loads_profile_and_creates_model(self, mock_config, mock_get_model):
-        """Test that profile is loaded and model is created."""
-        mock_profile = LLMProfileConfig(
-            provider="anthropic", model="claude-haiku-4-5", api_key="test-key"
-        )
-        mock_config.get_llm_profile.return_value = mock_profile
-        mock_model = MagicMock()
-        mock_get_model.return_value = mock_model
-
-        result = get_chat_model_by_profile_name("test_profile")
-
-        assert result is mock_model
-        mock_config.get_llm_profile.assert_called_once_with("test_profile")
-        mock_get_model.assert_called_once_with(mock_profile)
 
 
 class TestProviderConstructors:

--- a/ui/components/environment_check.py
+++ b/ui/components/environment_check.py
@@ -9,9 +9,16 @@ from src.config import config
 
 def get_missing_api_keys() -> set[str]:
     """Return the set of API-key env var names required by configured tasks
-    that are currently missing."""
+    that are currently missing.
+
+    Iterates fields via Pydantic's public ``model_fields`` API rather than
+    ``vars()``/``__dict__``, which is an undocumented implementation detail
+    and could include non-field values in future Pydantic versions.
+    """
     missing_keys: set[str] = set()
-    for _task_name, agent_llm in vars(config.agent_tasks).items():
+    agent_tasks = config.agent_tasks
+    for field_name in type(agent_tasks).model_fields:
+        agent_llm = getattr(agent_tasks, field_name)
         if not agent_llm.api_key:
             provider = agent_llm.provider.upper()
             missing_keys.add(f"{provider}_API_KEY")

--- a/ui/components/environment_check.py
+++ b/ui/components/environment_check.py
@@ -16,7 +16,7 @@ def check_environment_setup() -> tuple[bool, str]:
         missing_keys = set()
 
         # Check each agent task's LLM config for missing API keys
-        for _task_name, agent_llm in vars(config.agents).items():
+        for _task_name, agent_llm in vars(config.agent_tasks).items():
             if not agent_llm.api_key:
                 provider = agent_llm.provider.upper()
                 missing_keys.add(f"{provider}_API_KEY")

--- a/ui/components/environment_check.py
+++ b/ui/components/environment_check.py
@@ -7,20 +7,21 @@ import streamlit as st
 from src.config import config
 
 
+def get_missing_api_keys() -> set[str]:
+    """Return the set of API-key env var names required by configured tasks
+    that are currently missing."""
+    missing_keys: set[str] = set()
+    for _task_name, agent_llm in vars(config.agent_tasks).items():
+        if not agent_llm.api_key:
+            provider = agent_llm.provider.upper()
+            missing_keys.add(f"{provider}_API_KEY")
+    return missing_keys
+
+
 def check_environment_setup() -> tuple[bool, str]:
     """Check if the environment is properly configured"""
     try:
-        # Check if configs can be loaded
-        # config is already imported at module level
-
-        missing_keys = set()
-
-        # Check each agent task's LLM config for missing API keys
-        for _task_name, agent_llm in vars(config.agent_tasks).items():
-            if not agent_llm.api_key:
-                provider = agent_llm.provider.upper()
-                missing_keys.add(f"{provider}_API_KEY")
-
+        missing_keys = get_missing_api_keys()
         if missing_keys:
             missing_str = ", ".join(sorted(missing_keys))
             return False, f"Missing required API keys: {missing_str}"
@@ -30,20 +31,40 @@ def check_environment_setup() -> tuple[bool, str]:
         return False, f"Configuration error: {str(e)}"
 
 
+def build_setup_instructions(missing_keys: set[str]) -> str:
+    """Build setup instructions that reference the actual missing API keys.
+
+    Keeps the instructions in sync with what the detector reports, so users
+    don't get told to configure a provider that the app isn't actually using.
+    """
+    if missing_keys:
+        sorted_keys = sorted(missing_keys)
+        key_lines = "\n".join(f"   - `{name}=your_key_here`" for name in sorted_keys)
+        keys_section = "2. Add the missing API key(s) listed above:\n" + key_lines
+    else:
+        keys_section = "2. Add the required API key(s) for your configured providers"
+
+    return f"""
+**Setup Instructions:**
+1. Create a `.env` file in the root directory
+{keys_section}
+3. Restart the Streamlit app
+
+Optional: Add Langfuse keys for observability:
+- `LANGFUSE_PUBLIC_KEY=your_public_key`
+- `LANGFUSE_SECRET_KEY=your_secret_key`
+- `LANGFUSE_ENABLED=true`
+"""
+
+
 def render_environment_warning():
     """Render environment setup warning if needed"""
     env_ok, env_message = check_environment_setup()
     if not env_ok:
         st.error(f"⚠️ **Setup Required:** {env_message}")
-        st.info("""
-        **Setup Instructions:**
-        1. Create a `.env` file in the root directory
-        2. Add your Anthropic API key: `ANTHROPIC_API_KEY=your_key_here`
-        3. Restart the Streamlit app
-
-        Optional: Add Langfuse keys for observability:
-        - `LANGFUSE_PUBLIC_KEY=your_public_key`
-        - `LANGFUSE_SECRET_KEY=your_secret_key`
-        - `LANGFUSE_ENABLED=true`
-        """)
+        try:
+            missing_keys = get_missing_api_keys()
+        except Exception:
+            missing_keys = set()
+        st.info(build_setup_instructions(missing_keys))
     return env_ok

--- a/ui/components/environment_check.py
+++ b/ui/components/environment_check.py
@@ -13,17 +13,16 @@ def check_environment_setup() -> tuple[bool, str]:
         # Check if configs can be loaded
         # config is already imported at module level
 
-        missing_keys = []
+        missing_keys = set()
 
-        # Check each LLM profile for missing API keys
-        for profile_name, profile in config.llm_profiles.items():
-            if not profile.api_key:
-                provider = profile.provider.upper()
-                env_var = f"{provider}_API_KEY"
-                missing_keys.append(env_var)
+        # Check each agent task's LLM config for missing API keys
+        for _task_name, agent_llm in vars(config.agents).items():
+            if not agent_llm.api_key:
+                provider = agent_llm.provider.upper()
+                missing_keys.add(f"{provider}_API_KEY")
 
         if missing_keys:
-            missing_str = ", ".join(missing_keys)
+            missing_str = ", ".join(sorted(missing_keys))
             return False, f"Missing required API keys: {missing_str}"
 
         return True, "Environment is properly configured"


### PR DESCRIPTION
Simplify LLM configuration by having each agent task directly define its own provider, model, and sampling settings, replacing the two-layer `llm_profiles` + `agents` (task -> profile-name) indirection.

- Inline per-task LLM config under `[agent_tasks.<task>]` in `configs/base.toml`; drop the 5 previously unused profiles
- Make `AgentTasksConfig` fields typed `LLMProfileConfig`; remove the `llm_profiles` field and the `get_llm_profile`/`get_agent_llm_profile` helpers from `AppConfig`
- Inject API keys per agent task in the config loader, and rework the UI environment check to iterate tasks via Pydantic's `model_fields` (deduping shared providers) and render setup instructions that reflect the actually-missing keys
- Remove `get_chat_model_by_profile_name`; callsites now pass `config.agent_tasks.<task>` straight to `get_chat_model`
- Update tests (incl. real `AgentTasksConfig` fixtures for the env check) and config docs to the new shape

Per-task overrides in `dev.toml`/`prod.toml` now apply to a single task instead of every task sharing a profile. The four interview tasks are duplicated inline for now; a shared `[llm_defaults]` table is a natural follow-up if that becomes painful.

## Testing
- `uv run pytest` (300 passed)
- `uv run ruff check` (clean)
- Smoke-checked config load under dev and prod

Refs: JSA-40