### PR TITLE
feat(llm): add call-resilience builder with retry and cross-provider fallback

### DIFF
--- a/src/llm/__init__.py
+++ b/src/llm/__init__.py
@@ -7,10 +7,18 @@ instances for different providers.
 
 from src.llm.factory import get_chat_model
 from src.llm.langfuse import GlobalLangfuseManager, LangfuseManager, langfuse_manager
+from src.llm.resilience import (
+    TransientLLMError,
+    build_resilient_llm,
+    is_transient_error,
+)
 
 __all__ = [
     "get_chat_model",
     "LangfuseManager",
     "GlobalLangfuseManager",
     "langfuse_manager",
+    "build_resilient_llm",
+    "is_transient_error",
+    "TransientLLMError",
 ]

--- a/src/llm/factory.py
+++ b/src/llm/factory.py
@@ -20,6 +20,13 @@ _PROVIDER_CONSTRUCTORS = {
     "google": "_create_google_model",
 }
 
+# Single source of truth for provider -> API key env var name, shared with
+# src/llm/resilience.py so the two stay in sync as providers are added.
+PROVIDER_ENV_VARS = {
+    "anthropic": "ANTHROPIC_API_KEY",
+    "google": "GOOGLE_API_KEY",
+}
+
 
 def _ensure_api_key(config: LLMConfig, env_var_name: str) -> str:
     """Get API key from config or environment, raising if missing."""
@@ -38,7 +45,7 @@ def _ensure_api_key(config: LLMConfig, env_var_name: str) -> str:
 def _create_anthropic_model(config: LLMConfig) -> BaseChatModel:
     from langchain_anthropic import ChatAnthropic
 
-    api_key = _ensure_api_key(config, "ANTHROPIC_API_KEY")
+    api_key = _ensure_api_key(config, PROVIDER_ENV_VARS["anthropic"])
     return ChatAnthropic(
         model=config.model,
         temperature=config.temperature,
@@ -50,7 +57,7 @@ def _create_anthropic_model(config: LLMConfig) -> BaseChatModel:
 def _create_google_model(config: LLMConfig) -> BaseChatModel:
     from langchain_google_genai import ChatGoogleGenerativeAI
 
-    api_key = _ensure_api_key(config, "GOOGLE_API_KEY")
+    api_key = _ensure_api_key(config, PROVIDER_ENV_VARS["google"])
     return ChatGoogleGenerativeAI(
         model=config.model,
         temperature=config.temperature,

--- a/src/llm/resilience.py
+++ b/src/llm/resilience.py
@@ -14,7 +14,7 @@ malformed / unknown -> surface immediately so real bugs aren't masked).
 """
 
 import os
-from typing import Any, Optional, Tuple, Type
+from typing import Any, Dict, List, Optional, Tuple, Type
 
 from langchain_core.exceptions import OutputParserException
 from langchain_core.language_models import BaseChatModel
@@ -62,7 +62,7 @@ def _build_transient_type_tuple() -> Tuple[Type[BaseException], ...]:
     # cross-provider fallback (which is what actually helps) kicks in. Still
     # worth retrying since not every task runs at temperature=0.0, and a
     # transient upstream glitch can also produce a one-off malformed response.
-    types: list[Type[BaseException]] = [OutputParserException, ValidationError]
+    types: List[Type[BaseException]] = [OutputParserException, ValidationError]
 
     try:
         import httpx
@@ -195,7 +195,7 @@ def _build_leaf(
     role: str,
     max_attempts_per_provider: int,
     wait_exponential_jitter: bool,
-    exponential_jitter_params: Optional[dict],
+    exponential_jitter_params: Optional[Dict[str, Any]],
 ) -> Runnable:
     """Build a single resilient provider leaf: structured-output + retry."""
     model: BaseChatModel = get_chat_model(config)
@@ -212,7 +212,7 @@ def _build_leaf(
 
     guarded = _guard_leaf(bound, config, role)
 
-    retry_kwargs: dict[str, Any] = {
+    retry_kwargs: Dict[str, Any] = {
         "retry_if_exception_type": (TransientLLMError,),
         "wait_exponential_jitter": wait_exponential_jitter,
         "stop_after_attempt": max_attempts_per_provider,
@@ -230,7 +230,7 @@ def build_resilient_llm(
     output_model: Optional[Type[BaseModel]] = None,
     max_attempts_per_provider: int = DEFAULT_MAX_ATTEMPTS_PER_PROVIDER,
     wait_exponential_jitter: bool = True,
-    exponential_jitter_params: Optional[dict] = None,
+    exponential_jitter_params: Optional[Dict[str, Any]] = None,
 ) -> Runnable:
     """Build a resilient runnable: same-provider retry under cross-provider fallback.
 

--- a/src/llm/resilience.py
+++ b/src/llm/resilience.py
@@ -23,7 +23,7 @@ from pydantic import BaseModel, ValidationError
 
 from src.config.models import LLMConfig
 from src.exceptions.llm import LLMError
-from src.llm.factory import get_chat_model
+from src.llm.factory import PROVIDER_ENV_VARS, get_chat_model
 from src.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -36,11 +36,6 @@ DEFAULT_MAX_ATTEMPTS_PER_PROVIDER = 3
 # provider lumps several failure modes under one exception type (the Google
 # ``genai`` SDK in particular raises a single ``ClientError`` for all 4xx).
 _TRANSIENT_STATUS_CODES = frozenset({408, 409, 425, 429})
-
-_PROVIDER_ENV_VARS = {
-    "anthropic": "ANTHROPIC_API_KEY",
-    "google": "GOOGLE_API_KEY",
-}
 
 
 class TransientLLMError(LLMError):
@@ -140,7 +135,7 @@ def _has_api_key(config: LLMConfig) -> bool:
     """Return whether an API key is resolvable for the config's provider."""
     if getattr(config, "api_key", None):
         return True
-    env_var = _PROVIDER_ENV_VARS.get(config.provider.lower())
+    env_var = PROVIDER_ENV_VARS.get(config.provider.lower())
     return bool(env_var and os.getenv(env_var))
 
 

--- a/src/llm/resilience.py
+++ b/src/llm/resilience.py
@@ -44,12 +44,15 @@ _PROVIDER_ENV_VARS = {
 
 
 class TransientLLMError(LLMError):
-    """Internal marker wrapping an underlying transient failure.
+    """Raised when a transient LLM failure exhausts all retries and fallbacks.
 
-    The classifier converts any provider/framework exception it deems transient
-    into this single type, so the native ``with_retry`` / ``with_fallbacks``
+    Internally, the classifier wraps each transient provider/framework failure
+    into this single type so the native ``with_retry`` / ``with_fallbacks``
     type filters can act on one unambiguous class while non-transient errors
-    keep their original type and fail fast.
+    keep their original type and fail fast. This is also what callers of a
+    runnable built by :func:`build_resilient_llm` will see raised if the
+    primary's retries *and* the fallback's retries are all exhausted; the
+    original provider exception is preserved via ``__cause__``.
     """
 
 
@@ -247,6 +250,13 @@ def build_resilient_llm(
     Returns:
         A LangChain ``Runnable`` to ``.invoke(messages, config=...)``. Pass the
         Langfuse config so tracing propagates across the fallback boundary.
+
+    Raises:
+        TransientLLMError: If the primary's retries and the fallback's retries
+            (when a fallback is configured) are all exhausted. The original
+            provider exception is available via ``__cause__``. Non-transient
+            errors (auth, malformed input, unknown) propagate with their
+            original type instead.
     """
     primary_leaf = _build_leaf(
         primary_config,

--- a/src/llm/resilience.py
+++ b/src/llm/resilience.py
@@ -179,12 +179,11 @@ def _guard_leaf(runnable: Runnable, config: LLMConfig, role: str) -> Runnable:
                     details={"provider": provider, "model": model, "role": role},
                 ) from exc
             raise
-        logger.info(
-            "LLM response served by provider=%s model=%s (role=%s)",
-            provider,
-            model,
-            role,
-        )
+        # Routine primary success is expected on every call and would be pure
+        # noise at INFO; the fallback actually serving is the degradation
+        # signal worth surfacing by default.
+        log = logger.info if role == "fallback" else logger.debug
+        log("LLM response served by provider=%s model=%s (role=%s)", provider, model, role)
         return result
 
     return RunnableLambda(_invoke, name=f"resilient_{role}_{provider}")

--- a/src/llm/resilience.py
+++ b/src/llm/resilience.py
@@ -254,6 +254,12 @@ def build_resilient_llm(
         A LangChain ``Runnable`` to ``.invoke(messages, config=...)``. Pass the
         Langfuse config so tracing propagates across the fallback boundary.
 
+        Note: there is no aggregate deadline across retries + fallback. Worst
+        case latency is roughly ``max_attempts_per_provider`` x number of
+        providers, plus exponential backoff between attempts. Fine for
+        best-effort batch jobs; revisit with an overall timeout if this is
+        ever wired into a latency-sensitive (e.g. interactive) path.
+
     Raises:
         ValueError: If ``max_attempts_per_provider`` is not a positive integer.
             Notably, Tenacity's ``stop_after_attempt`` treats 0 or a negative

--- a/src/llm/resilience.py
+++ b/src/llm/resilience.py
@@ -147,12 +147,16 @@ def _has_api_key(config: LLMConfig) -> bool:
 def _guard_leaf(runnable: Runnable, config: LLMConfig, role: str) -> Runnable:
     """Wrap a model/structured runnable to normalize errors and log who served.
 
+    ``config`` identifies this leaf's provider/model for logging only. The
+    separate ``run_config`` received by the wrapped invocation (the
+    ``RunnableConfig`` supplied by the caller at ``.invoke()`` time, carrying
+    the Langfuse callbacks) is forwarded unchanged to ``runnable.invoke()``, so
+    tracing propagates across the fallback boundary too.
+
     Transient failures are re-raised as ``TransientLLMError`` (the single type
     the retry/fallback filters watch); non-transient failures propagate
     unchanged (fail fast). On success it logs which provider+model actually
-    served the response, making primary-provider degradation observable. The
-    incoming ``config`` (carrying the Langfuse callbacks) is forwarded so
-    tracing propagates to the fallback runnable too.
+    served the response, making primary-provider degradation observable.
     """
     provider, model = config.provider, config.model
 

--- a/src/llm/resilience.py
+++ b/src/llm/resilience.py
@@ -54,8 +54,10 @@ class TransientLLMError(LLMError):
 def _build_transient_type_tuple() -> Tuple[Type[BaseException], ...]:
     """Collect always-transient exception types from whatever SDKs are present.
 
-    Imports are best-effort so a single-provider install (or a missing optional
-    dependency) never breaks the classifier.
+    Imports are best-effort (not because these provider SDKs are optional
+    dependencies today - they're hard transitive deps via langchain-anthropic /
+    langchain-google-genai) so the classifier stays import-safe if that ever
+    changes, or in an environment missing one of them.
     """
     # Trade-off: at temperature=0.0 a parse failure is close to deterministic,
     # so same-provider retries here are likely to re-fail before the
@@ -89,7 +91,7 @@ def _build_transient_type_tuple() -> Tuple[Type[BaseException], ...]:
         # (rate limits, 5xx/overloaded) are handled separately below via
         # status_code inspection, since APIStatusError covers many status codes.
         types += [anthropic.APIConnectionError]
-    except ImportError:  # pragma: no cover - provider package optional
+    except ImportError:  # pragma: no cover - best-effort import guard, keeps this import-safe
         pass
 
     return tuple(types)
@@ -122,7 +124,7 @@ def is_transient_error(exc: BaseException) -> bool:
             return status_code is not None and (
                 status_code >= 500 or status_code in _TRANSIENT_STATUS_CODES
             )
-    except ImportError:  # pragma: no cover - provider package optional
+    except ImportError:  # pragma: no cover - best-effort import guard, keeps this import-safe
         pass
 
     # Google's ``genai`` SDK raises a single ``ServerError`` for 5xx and a
@@ -130,7 +132,7 @@ def is_transient_error(exc: BaseException) -> bool:
     # from fail-fast 400/401/403 by inspecting the HTTP status code.
     try:
         from google.genai import errors as genai_errors
-    except ImportError:  # pragma: no cover - provider package optional
+    except ImportError:  # pragma: no cover - best-effort import guard, keeps this import-safe
         return False
 
     if isinstance(exc, genai_errors.ServerError):
@@ -168,6 +170,9 @@ def _guard_leaf(runnable: Runnable, config: LLMConfig, role: str) -> Runnable:
     the retry/fallback filters watch); non-transient failures propagate
     unchanged (fail fast). On success it logs which provider+model actually
     served the response, making primary-provider degradation observable.
+
+    Sync-only today: only ``invoke`` is wrapped, no ``ainvoke``/``afunc``. Add
+    an async counterpart if a caller ever needs to ``.ainvoke()`` this chain.
     """
     provider, model = config.provider, config.model
 

--- a/src/llm/resilience.py
+++ b/src/llm/resilience.py
@@ -144,7 +144,7 @@ def _guard_leaf(runnable: Runnable, config: LLMConfig, role: str) -> Runnable:
             result = runnable.invoke(value, config=run_config)
         except TransientLLMError:
             raise
-        except BaseException as exc:
+        except Exception as exc:
             if is_transient_error(exc):
                 logger.warning(
                     "Transient LLM error from provider=%s model=%s (role=%s): %s",

--- a/src/llm/resilience.py
+++ b/src/llm/resilience.py
@@ -14,7 +14,7 @@ malformed / unknown -> surface immediately so real bugs aren't masked).
 """
 
 import os
-from typing import Any, Dict, List, Optional, Tuple, Type
+from typing import Any, Dict, List, Mapping, Optional, Tuple, Type
 
 from langchain_core.exceptions import OutputParserException
 from langchain_core.language_models import BaseChatModel
@@ -206,7 +206,7 @@ def _build_leaf(
     role: str,
     max_attempts_per_provider: int,
     wait_exponential_jitter: bool,
-    exponential_jitter_params: Optional[Dict[str, Any]],
+    exponential_jitter_params: Optional[Mapping[str, Any]],
 ) -> Runnable:
     """Build a single resilient provider leaf: structured-output + retry."""
     model: BaseChatModel = get_chat_model(config)
@@ -241,7 +241,7 @@ def build_resilient_llm(
     output_model: Optional[Type[BaseModel]] = None,
     max_attempts_per_provider: int = DEFAULT_MAX_ATTEMPTS_PER_PROVIDER,
     wait_exponential_jitter: bool = True,
-    exponential_jitter_params: Optional[Dict[str, Any]] = None,
+    exponential_jitter_params: Optional[Mapping[str, Any]] = None,
 ) -> Runnable:
     """Build a resilient runnable: same-provider retry under cross-provider fallback.
 

--- a/src/llm/resilience.py
+++ b/src/llm/resilience.py
@@ -252,12 +252,22 @@ def build_resilient_llm(
         Langfuse config so tracing propagates across the fallback boundary.
 
     Raises:
+        ValueError: If ``max_attempts_per_provider`` is not a positive integer.
+            Notably, Tenacity's ``stop_after_attempt`` treats 0 or a negative
+            value as "never stop", which would otherwise retry forever instead
+            of failing fast.
         TransientLLMError: If the primary's retries and the fallback's retries
             (when a fallback is configured) are all exhausted. The original
             provider exception is available via ``__cause__``. Non-transient
             errors (auth, malformed input, unknown) propagate with their
             original type instead.
     """
+    if max_attempts_per_provider < 1:
+        raise ValueError(
+            f"max_attempts_per_provider must be >= 1, got {max_attempts_per_provider} "
+            "(0 or negative would retry forever under Tenacity's stop_after_attempt)."
+        )
+
     primary_leaf = _build_leaf(
         primary_config,
         output_model,

--- a/src/llm/resilience.py
+++ b/src/llm/resilience.py
@@ -235,7 +235,11 @@ def build_resilient_llm(
     """Build a resilient runnable: same-provider retry under cross-provider fallback.
 
     Args:
-        primary_config: LLM config for the primary provider/model.
+        primary_config: LLM config for the primary provider/model. Unlike the
+            fallback, a missing primary API key is *not* handled gracefully:
+            it raises ``LLMProviderError`` eagerly (via ``get_chat_model``)
+            since a misconfigured primary is a config bug, not a runtime
+            condition to degrade around.
         fallback_config: Optional tier-matched fallback on a different provider.
             If omitted, or if its API key is not configured, the fallback is
             skipped gracefully and only the primary (with retries) is used - so

--- a/src/llm/resilience.py
+++ b/src/llm/resilience.py
@@ -147,11 +147,17 @@ def _has_api_key(config: LLMConfig) -> bool:
 def _guard_leaf(runnable: Runnable, config: LLMConfig, role: str) -> Runnable:
     """Wrap a model/structured runnable to normalize errors and log who served.
 
-    ``config`` identifies this leaf's provider/model for logging only. The
-    separate ``run_config`` received by the wrapped invocation (the
-    ``RunnableConfig`` supplied by the caller at ``.invoke()`` time, carrying
-    the Langfuse callbacks) is forwarded unchanged to ``runnable.invoke()``, so
-    tracing propagates across the fallback boundary too.
+    The outer ``config: LLMConfig`` identifies this leaf's provider/model for
+    logging only. The inner callback's ``config: Optional[RunnableConfig]``
+    parameter must be named exactly ``config`` - LangChain's
+    ``accepts_config()`` only injects the caller's ``RunnableConfig`` (with
+    Langfuse callbacks/tags) into a wrapped callable when the parameter is
+    literally named ``config``; any other name (e.g. ``run_config``) is never
+    populated. We forward it explicitly to ``runnable.invoke()`` as
+    belt-and-braces; today, callbacks also propagate independently via
+    LangChain's config contextvar regardless of this parameter's name, but the
+    explicit forwarding is what the parameter name must match to actually
+    fire, and is what protects us if that contextvar behavior ever changes.
 
     Transient failures are re-raised as ``TransientLLMError`` (the single type
     the retry/fallback filters watch); non-transient failures propagate
@@ -160,9 +166,9 @@ def _guard_leaf(runnable: Runnable, config: LLMConfig, role: str) -> Runnable:
     """
     provider, model = config.provider, config.model
 
-    def _invoke(value: Any, run_config: Optional[RunnableConfig] = None) -> Any:
+    def _invoke(value: Any, config: Optional[RunnableConfig] = None) -> Any:
         try:
-            result = runnable.invoke(value, config=run_config)
+            result = runnable.invoke(value, config=config)
         except TransientLLMError:
             raise
         except Exception as exc:

--- a/src/llm/resilience.py
+++ b/src/llm/resilience.py
@@ -57,6 +57,11 @@ def _build_transient_type_tuple() -> Tuple[Type[BaseException], ...]:
     Imports are best-effort so a single-provider install (or a missing optional
     dependency) never breaks the classifier.
     """
+    # Trade-off: at temperature=0.0 a parse failure is close to deterministic,
+    # so same-provider retries here are likely to re-fail before the
+    # cross-provider fallback (which is what actually helps) kicks in. Still
+    # worth retrying since not every task runs at temperature=0.0, and a
+    # transient upstream glitch can also produce a one-off malformed response.
     types: list[Type[BaseException]] = [OutputParserException, ValidationError]
 
     try:

--- a/src/llm/resilience.py
+++ b/src/llm/resilience.py
@@ -1,0 +1,277 @@
+"""
+LLM call-resilience building block.
+
+This is the first, reusable instance of the call-resilience pattern: it answers
+"did we get a valid response object at all?" (timeouts, rate limits, 5xx,
+connection drops, and structured-output parse failures), separate from the
+quality layer (the workflow's critic gates).
+
+Mechanism: LangChain-native, Tenacity-backed. Each provider model is bound to
+its structured-output schema *before* being composed, then wrapped with a
+same-provider transient retry (``with_retry``) and finally placed under a
+cross-provider fallback (``with_fallbacks``). A provider-agnostic classifier
+decides what counts as transient (retry + fall back) versus fail-fast (auth /
+malformed / unknown -> surface immediately so real bugs aren't masked).
+"""
+
+import os
+from typing import Any, Optional, Tuple, Type
+
+from langchain_core.exceptions import OutputParserException
+from langchain_core.language_models import BaseChatModel
+from langchain_core.runnables import Runnable, RunnableConfig, RunnableLambda
+from pydantic import BaseModel, ValidationError
+
+from src.config.models import LLMConfig
+from src.exceptions.llm import LLMError
+from src.llm.factory import get_chat_model
+from src.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+# Default same-provider attempts before falling back. T2 wires this from the
+# global ``[llm.resilience]`` config; kept as a plain argument here so this
+# building block has no dependency on the (later) config additions.
+DEFAULT_MAX_ATTEMPTS_PER_PROVIDER = 3
+
+# HTTP status codes that represent a transient, retryable condition when a
+# provider lumps several failure modes under one exception type (the Google
+# ``genai`` SDK in particular raises a single ``ClientError`` for all 4xx).
+_TRANSIENT_STATUS_CODES = frozenset({408, 409, 425, 429})
+
+_PROVIDER_ENV_VARS = {
+    "anthropic": "ANTHROPIC_API_KEY",
+    "google": "GOOGLE_API_KEY",
+}
+
+
+class TransientLLMError(LLMError):
+    """Internal marker wrapping an underlying transient failure.
+
+    The classifier converts any provider/framework exception it deems transient
+    into this single type, so the native ``with_retry`` / ``with_fallbacks``
+    type filters can act on one unambiguous class while non-transient errors
+    keep their original type and fail fast.
+    """
+
+
+def _build_transient_type_tuple() -> Tuple[Type[BaseException], ...]:
+    """Collect always-transient exception types from whatever SDKs are present.
+
+    Imports are best-effort so a single-provider install (or a missing optional
+    dependency) never breaks the classifier.
+    """
+    types: list[Type[BaseException]] = [OutputParserException, ValidationError]
+
+    try:
+        import httpx
+
+        types += [
+            httpx.TimeoutException,
+            httpx.ConnectError,
+            httpx.ReadError,
+            httpx.RemoteProtocolError,
+            httpx.PoolTimeout,
+        ]
+    except ImportError:  # pragma: no cover - httpx is a hard dependency
+        pass
+
+    try:
+        import anthropic
+
+        types += [
+            anthropic.APITimeoutError,
+            anthropic.APIConnectionError,
+            anthropic.RateLimitError,
+            anthropic.InternalServerError,
+        ]
+    except ImportError:  # pragma: no cover - provider package optional
+        pass
+
+    return tuple(types)
+
+
+_TRANSIENT_EXCEPTION_TYPES: Tuple[Type[BaseException], ...] = _build_transient_type_tuple()
+
+
+def is_transient_error(exc: BaseException) -> bool:
+    """Classify an exception as transient (retry + fall back) or fail-fast.
+
+    Transient: timeouts, connection drops, rate limits, 5xx/service-unavailable,
+    and structured-output parse/validation failures. Everything else - auth
+    errors (a config bug), clearly-malformed 4xx, and unknown exceptions - is
+    fail-fast so genuine errors surface instead of being silently retried away.
+    """
+    if isinstance(exc, _TRANSIENT_EXCEPTION_TYPES):
+        return True
+
+    # Google's ``genai`` SDK raises a single ``ServerError`` for 5xx and a
+    # single ``ClientError`` for all 4xx, so transient 429s must be told apart
+    # from fail-fast 400/401/403 by inspecting the HTTP status code.
+    try:
+        from google.genai import errors as genai_errors
+    except ImportError:  # pragma: no cover - provider package optional
+        return False
+
+    if isinstance(exc, genai_errors.ServerError):
+        return True
+    if isinstance(exc, genai_errors.APIError):
+        return getattr(exc, "code", None) in _TRANSIENT_STATUS_CODES
+
+    return False
+
+
+def _has_api_key(config: LLMConfig) -> bool:
+    """Return whether an API key is resolvable for the config's provider."""
+    if getattr(config, "api_key", None):
+        return True
+    env_var = _PROVIDER_ENV_VARS.get(config.provider.lower())
+    return bool(env_var and os.getenv(env_var))
+
+
+def _guard_leaf(runnable: Runnable, config: LLMConfig, role: str) -> Runnable:
+    """Wrap a model/structured runnable to normalize errors and log who served.
+
+    Transient failures are re-raised as ``TransientLLMError`` (the single type
+    the retry/fallback filters watch); non-transient failures propagate
+    unchanged (fail fast). On success it logs which provider+model actually
+    served the response, making primary-provider degradation observable. The
+    incoming ``config`` (carrying the Langfuse callbacks) is forwarded so
+    tracing propagates to the fallback runnable too.
+    """
+    provider, model = config.provider, config.model
+
+    def _invoke(value: Any, run_config: Optional[RunnableConfig] = None) -> Any:
+        try:
+            result = runnable.invoke(value, config=run_config)
+        except TransientLLMError:
+            raise
+        except BaseException as exc:
+            if is_transient_error(exc):
+                logger.warning(
+                    "Transient LLM error from provider=%s model=%s (role=%s): %s",
+                    provider,
+                    model,
+                    role,
+                    exc,
+                )
+                raise TransientLLMError(
+                    f"Transient error from {provider}/{model}: {exc}",
+                    details={"provider": provider, "model": model, "role": role},
+                ) from exc
+            raise
+        logger.info(
+            "LLM response served by provider=%s model=%s (role=%s)",
+            provider,
+            model,
+            role,
+        )
+        return result
+
+    return RunnableLambda(_invoke, name=f"resilient_{role}_{provider}")
+
+
+def _build_leaf(
+    config: LLMConfig,
+    output_model: Optional[Type[BaseModel]],
+    role: str,
+    max_attempts_per_provider: int,
+    wait_exponential_jitter: bool,
+    exponential_jitter_params: Optional[dict],
+) -> Runnable:
+    """Build a single resilient provider leaf: structured-output + retry."""
+    model: BaseChatModel = get_chat_model(config)
+    if output_model is not None:
+        # include_raw=False is REQUIRED: with include_raw=True a schema-validation
+        # failure is swallowed into a ``parsing_error`` key and never raises, so
+        # neither the retry nor the fallback would ever trigger. Binding the
+        # schema per model here (before any fallback composition) also avoids the
+        # introspection bug from calling with_structured_output on a
+        # RunnableWithFallbacks.
+        bound: Runnable = model.with_structured_output(output_model, include_raw=False)
+    else:
+        bound = model
+
+    guarded = _guard_leaf(bound, config, role)
+
+    retry_kwargs: dict[str, Any] = {
+        "retry_if_exception_type": (TransientLLMError,),
+        "wait_exponential_jitter": wait_exponential_jitter,
+        "stop_after_attempt": max_attempts_per_provider,
+    }
+    if exponential_jitter_params is not None:
+        retry_kwargs["exponential_jitter_params"] = exponential_jitter_params
+
+    return guarded.with_retry(**retry_kwargs)
+
+
+def build_resilient_llm(
+    primary_config: LLMConfig,
+    fallback_config: Optional[LLMConfig] = None,
+    *,
+    output_model: Optional[Type[BaseModel]] = None,
+    max_attempts_per_provider: int = DEFAULT_MAX_ATTEMPTS_PER_PROVIDER,
+    wait_exponential_jitter: bool = True,
+    exponential_jitter_params: Optional[dict] = None,
+) -> Runnable:
+    """Build a resilient runnable: same-provider retry under cross-provider fallback.
+
+    Args:
+        primary_config: LLM config for the primary provider/model.
+        fallback_config: Optional tier-matched fallback on a different provider.
+            If omitted, or if its API key is not configured, the fallback is
+            skipped gracefully and only the primary (with retries) is used - so
+            single-key environments don't crash.
+        output_model: Optional Pydantic schema; when given, each provider is
+            bound via ``with_structured_output(include_raw=False)`` so parse
+            failures raise and trigger retry/fallback.
+        max_attempts_per_provider: Same-provider transient attempts before
+            either falling back (if a fallback exists) or failing.
+        wait_exponential_jitter: Use exponential backoff with jitter between
+            same-provider attempts.
+        exponential_jitter_params: Optional fine-grained backoff parameters
+            forwarded to LangChain's ``with_retry`` (e.g. initial/max/exp_base).
+
+    Returns:
+        A LangChain ``Runnable`` to ``.invoke(messages, config=...)``. Pass the
+        Langfuse config so tracing propagates across the fallback boundary.
+    """
+    primary_leaf = _build_leaf(
+        primary_config,
+        output_model,
+        "primary",
+        max_attempts_per_provider,
+        wait_exponential_jitter,
+        exponential_jitter_params,
+    )
+
+    if fallback_config is None:
+        logger.debug(
+            "No fallback configured for provider=%s model=%s; using primary retries only.",
+            primary_config.provider,
+            primary_config.model,
+        )
+        return primary_leaf
+
+    if not _has_api_key(fallback_config):
+        logger.warning(
+            "Fallback provider '%s' API key not configured; skipping fallback and "
+            "relying on primary (%s) retries only.",
+            fallback_config.provider,
+            primary_config.provider,
+        )
+        return primary_leaf
+
+    fallback_leaf = _build_leaf(
+        fallback_config,
+        output_model,
+        "fallback",
+        max_attempts_per_provider,
+        wait_exponential_jitter,
+        exponential_jitter_params,
+    )
+
+    return primary_leaf.with_fallbacks(
+        [fallback_leaf],
+        exceptions_to_handle=(TransientLLMError,),
+    )

--- a/src/llm/resilience.py
+++ b/src/llm/resilience.py
@@ -62,6 +62,11 @@ def _build_transient_type_tuple() -> Tuple[Type[BaseException], ...]:
     # cross-provider fallback (which is what actually helps) kicks in. Still
     # worth retrying since not every task runs at temperature=0.0, and a
     # transient upstream glitch can also produce a one-off malformed response.
+    # Cost asymmetry to be aware of: a persistent output_model/schema bug (not
+    # a flake) burns the full budget on every request - up to
+    # 2 x max_attempts_per_provider billed calls when a fallback is configured
+    # - since every attempt on both providers repeats the same failure. Lower
+    # max_attempts_per_provider for a task if this becomes a concern.
     types: List[Type[BaseException]] = [OutputParserException, ValidationError]
 
     try:

--- a/src/llm/resilience.py
+++ b/src/llm/resilience.py
@@ -77,12 +77,10 @@ def _build_transient_type_tuple() -> Tuple[Type[BaseException], ...]:
     try:
         import anthropic
 
-        types += [
-            anthropic.APITimeoutError,
-            anthropic.APIConnectionError,
-            anthropic.RateLimitError,
-            anthropic.InternalServerError,
-        ]
+        # APITimeoutError subclasses APIConnectionError; status-carrying errors
+        # (rate limits, 5xx/overloaded) are handled separately below via
+        # status_code inspection, since APIStatusError covers many status codes.
+        types += [anthropic.APIConnectionError]
     except ImportError:  # pragma: no cover - provider package optional
         pass
 
@@ -102,6 +100,22 @@ def is_transient_error(exc: BaseException) -> bool:
     """
     if isinstance(exc, _TRANSIENT_EXCEPTION_TYPES):
         return True
+
+    # Anthropic's SDK carries the HTTP status on every APIStatusError subclass
+    # (RateLimitError=429, ServiceUnavailableError=503, OverloadedError=529,
+    # DeadlineExceededError=504, InternalServerError=5xx, ...), so inspecting
+    # status_code covers all of them without enumerating each subclass and
+    # tells them apart from fail-fast 400/401/403/404.
+    try:
+        import anthropic
+
+        if isinstance(exc, anthropic.APIStatusError):
+            status_code = getattr(exc, "status_code", None)
+            return status_code is not None and (
+                status_code >= 500 or status_code in _TRANSIENT_STATUS_CODES
+            )
+    except ImportError:  # pragma: no cover - provider package optional
+        pass
 
     # Google's ``genai`` SDK raises a single ``ServerError`` for 5xx and a
     # single ``ClientError`` for all 4xx, so transient 429s must be told apart

--- a/src/llm/resilience.py
+++ b/src/llm/resilience.py
@@ -1,10 +1,9 @@
 """
 LLM call-resilience building block.
 
-This is the first, reusable instance of the call-resilience pattern: it answers
-"did we get a valid response object at all?" (timeouts, rate limits, 5xx,
-connection drops, and structured-output parse failures), separate from the
-quality layer (the workflow's critic gates).
+A reusable call-resilience helper: it answers "did we get a valid response
+object at all?" (timeouts, rate limits, 5xx, connection drops, and
+structured-output parse failures), separate from any content-quality checks.
 
 Mechanism: LangChain-native, Tenacity-backed. Each provider model is bound to
 its structured-output schema *before* being composed, then wrapped with a
@@ -29,9 +28,8 @@ from src.utils.logging import get_logger
 
 logger = get_logger(__name__)
 
-# Default same-provider attempts before falling back. T2 wires this from the
-# global ``[llm.resilience]`` config; kept as a plain argument here so this
-# building block has no dependency on the (later) config additions.
+# Default number of same-provider attempts before falling back; overridable
+# per call so this building block stays independent of any external config.
 DEFAULT_MAX_ATTEMPTS_PER_PROVIDER = 3
 
 # HTTP status codes that represent a transient, retryable condition when a

--- a/tests/unit/llm/test_resilience.py
+++ b/tests/unit/llm/test_resilience.py
@@ -193,6 +193,32 @@ class TestBuildResilientLLM:
         model.with_structured_output.assert_called_once_with(_Schema, include_raw=False)
 
     @patch("src.llm.resilience.get_chat_model")
+    def test_structured_output_parse_failure_falls_back(self, mock_get):
+        def raise_parse_error(_):
+            raise OutputParserException("bad json")
+
+        primary_model = MagicMock()
+        primary_model.with_structured_output.return_value = RunnableLambda(raise_parse_error)
+
+        fallback_model = MagicMock()
+        fallback_model.with_structured_output.return_value = RunnableLambda(
+            lambda _: _Schema(value=1)
+        )
+
+        mock_get.side_effect = [primary_model, fallback_model]
+
+        result = build_resilient_llm(
+            self._config(),
+            self._config(provider="google", model="gemini-2.5-flash-lite", api_key="k2"),
+            output_model=_Schema,
+            max_attempts_per_provider=1,
+        )
+
+        assert result.invoke("hi") == _Schema(value=1)
+        primary_model.with_structured_output.assert_called_once_with(_Schema, include_raw=False)
+        fallback_model.with_structured_output.assert_called_once_with(_Schema, include_raw=False)
+
+    @patch("src.llm.resilience.get_chat_model")
     def test_transient_primary_failure_falls_back(self, mock_get):
         attempts = {"primary": 0, "fallback": 0}
 

--- a/tests/unit/llm/test_resilience.py
+++ b/tests/unit/llm/test_resilience.py
@@ -21,6 +21,7 @@ from src.config.models import LLMConfig
 from src.exceptions.llm import LLMProviderError
 from src.llm.resilience import (
     TransientLLMError,
+    _has_api_key,
     build_resilient_llm,
     is_transient_error,
 )
@@ -73,8 +74,9 @@ class TestIsTransientError:
     def test_transient_exceptions(self, exc):
         assert is_transient_error(exc) is True
 
-    def test_google_rate_limit_is_transient(self):
-        assert is_transient_error(_google_error(429)) is True
+    @pytest.mark.parametrize("status_code", [408, 409, 425, 429])
+    def test_google_client_error_transient_status_codes(self, status_code):
+        assert is_transient_error(_google_error(status_code)) is True
 
     def test_google_server_error_is_transient(self):
         assert is_transient_error(_google_error(503)) is True
@@ -111,6 +113,28 @@ class TestIsTransientError:
     )
     def test_fail_fast_exceptions(self, exc):
         assert is_transient_error(exc) is False
+
+
+class TestHasApiKey:
+    """Direct unit coverage for _has_api_key's two resolution paths."""
+
+    def test_true_when_api_key_set_directly_on_config(self, monkeypatch):
+        monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+        config = LLMConfig(provider="google", model="gemini-2.5-flash-lite", api_key="k")
+
+        assert _has_api_key(config) is True
+
+    def test_true_when_env_var_set_and_config_key_absent(self, monkeypatch):
+        monkeypatch.setenv("GOOGLE_API_KEY", "env-key")
+        config = LLMConfig(provider="google", model="gemini-2.5-flash-lite", api_key=None)
+
+        assert _has_api_key(config) is True
+
+    def test_false_when_neither_config_key_nor_env_var_set(self, monkeypatch):
+        monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+        config = LLMConfig(provider="google", model="gemini-2.5-flash-lite", api_key=None)
+
+        assert _has_api_key(config) is False
 
 
 class TestBuildResilientLLM:

--- a/tests/unit/llm/test_resilience.py
+++ b/tests/unit/llm/test_resilience.py
@@ -300,6 +300,7 @@ class TestBuildResilientLLM:
             self._config(),
             self._config(provider="google", model="gemini-2.5-flash-lite", api_key="k2"),
             max_attempts_per_provider=2,
+            wait_exponential_jitter=False,
         )
 
         assert result.invoke("hi") == "FALLBACK"
@@ -342,6 +343,7 @@ class TestBuildResilientLLM:
             self._config(),
             self._config(provider="google", model="gemini-2.5-flash-lite", api_key="k2"),
             max_attempts_per_provider=2,
+            wait_exponential_jitter=False,
         )
 
         with pytest.raises(TransientLLMError) as exc_info:
@@ -360,7 +362,9 @@ class TestBuildResilientLLM:
 
         mock_get.return_value = RunnableLambda(primary)
 
-        result = build_resilient_llm(self._config(), max_attempts_per_provider=3)
+        result = build_resilient_llm(
+            self._config(), max_attempts_per_provider=3, wait_exponential_jitter=False
+        )
 
         with caplog.at_level("DEBUG"):
             assert result.invoke("hi") == "RECOVERED"

--- a/tests/unit/llm/test_resilience.py
+++ b/tests/unit/llm/test_resilience.py
@@ -1,0 +1,212 @@
+"""
+Unit tests for the LLM call-resilience building block.
+
+Covers the exception classifier (transient vs. fail-fast), the resilient
+runnable builder (retry + cross-provider fallback), graceful skipping of a
+fallback whose API key is missing, and structured-output binding with
+``include_raw=False``.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+from langchain_core.exceptions import OutputParserException
+from langchain_core.runnables import RunnableLambda
+from langchain_core.runnables.fallbacks import RunnableWithFallbacks
+from pydantic import BaseModel, ValidationError
+
+from src.config.models import LLMConfig
+from src.exceptions.llm import LLMProviderError
+from src.llm.resilience import (
+    build_resilient_llm,
+    is_transient_error,
+)
+
+
+class _Schema(BaseModel):
+    value: int
+
+
+def _make_validation_error() -> ValidationError:
+    try:
+        _Schema(value="not-an-int")
+    except ValidationError as exc:
+        return exc
+    raise AssertionError("expected ValidationError")
+
+
+def _anthropic_rate_limit() -> BaseException:
+    import anthropic
+
+    # Construct without running __init__ (its signature needs an httpx response);
+    # isinstance-based classification only cares about the type.
+    return anthropic.RateLimitError.__new__(anthropic.RateLimitError)
+
+
+def _google_error(code: int) -> BaseException:
+    from google.genai import errors as genai_errors
+
+    payload = {"error": {"message": "boom"}}
+    if code >= 500:
+        return genai_errors.ServerError(code, payload)
+    return genai_errors.ClientError(code, payload)
+
+
+class TestIsTransientError:
+    """The classifier maps exceptions to transient vs. fail-fast."""
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            httpx.TimeoutException("slow"),
+            httpx.ConnectError("no route"),
+            OutputParserException("bad json"),
+            _make_validation_error(),
+            _anthropic_rate_limit(),
+        ],
+    )
+    def test_transient_exceptions(self, exc):
+        assert is_transient_error(exc) is True
+
+    def test_google_rate_limit_is_transient(self):
+        assert is_transient_error(_google_error(429)) is True
+
+    def test_google_server_error_is_transient(self):
+        assert is_transient_error(_google_error(503)) is True
+
+    def test_google_bad_request_is_fail_fast(self):
+        assert is_transient_error(_google_error(400)) is False
+
+    def test_google_auth_error_is_fail_fast(self):
+        assert is_transient_error(_google_error(401)) is False
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            ValueError("nope"),
+            KeyError("missing"),
+            LLMProviderError("API key not found"),
+            RuntimeError("unknown"),
+        ],
+    )
+    def test_fail_fast_exceptions(self, exc):
+        assert is_transient_error(exc) is False
+
+
+class TestBuildResilientLLM:
+    """The builder composes retry + fallback and degrades gracefully."""
+
+    def _config(self, provider="anthropic", model="claude-haiku-4-5", api_key="k"):
+        return LLMConfig(provider=provider, model=model, api_key=api_key)
+
+    @patch("src.llm.resilience.get_chat_model")
+    def test_no_fallback_returns_primary_only(self, mock_get):
+        mock_get.return_value = RunnableLambda(lambda x: "ok")
+
+        result = build_resilient_llm(self._config())
+
+        assert not isinstance(result, RunnableWithFallbacks)
+        assert mock_get.call_count == 1
+
+    @patch("src.llm.resilience.get_chat_model")
+    def test_both_keys_present_composes_fallback(self, mock_get):
+        mock_get.side_effect = [RunnableLambda(lambda x: "p"), RunnableLambda(lambda x: "f")]
+
+        result = build_resilient_llm(
+            self._config(),
+            self._config(provider="google", model="gemini-2.5-flash-lite", api_key="k2"),
+        )
+
+        assert isinstance(result, RunnableWithFallbacks)
+        assert mock_get.call_count == 2
+
+    @patch("src.llm.resilience.get_chat_model")
+    def test_missing_fallback_key_skips_fallback(self, mock_get, monkeypatch, caplog):
+        monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        mock_get.return_value = RunnableLambda(lambda x: "p")
+        fallback = self._config(provider="google", model="gemini-2.5-flash-lite", api_key=None)
+
+        with caplog.at_level("WARNING"):
+            result = build_resilient_llm(self._config(), fallback)
+
+        assert not isinstance(result, RunnableWithFallbacks)
+        assert mock_get.call_count == 1
+        assert "skipping fallback" in caplog.text.lower()
+
+    @patch("src.llm.resilience.get_chat_model")
+    def test_structured_output_binds_include_raw_false(self, mock_get):
+        model = MagicMock()
+        mock_get.return_value = model
+
+        build_resilient_llm(self._config(), output_model=_Schema)
+
+        model.with_structured_output.assert_called_once_with(_Schema, include_raw=False)
+
+    @patch("src.llm.resilience.get_chat_model")
+    def test_transient_primary_failure_falls_back(self, mock_get):
+        attempts = {"primary": 0, "fallback": 0}
+
+        def primary(_):
+            attempts["primary"] += 1
+            raise httpx.ConnectError("down")
+
+        def fallback(_):
+            attempts["fallback"] += 1
+            return "FALLBACK"
+
+        mock_get.side_effect = [RunnableLambda(primary), RunnableLambda(fallback)]
+
+        result = build_resilient_llm(
+            self._config(),
+            self._config(provider="google", model="gemini-2.5-flash-lite", api_key="k2"),
+            max_attempts_per_provider=2,
+        )
+
+        assert result.invoke("hi") == "FALLBACK"
+        assert attempts["primary"] == 2
+        assert attempts["fallback"] == 1
+
+    @patch("src.llm.resilience.get_chat_model")
+    def test_fail_fast_error_is_not_retried_or_fallen_back(self, mock_get):
+        attempts = {"primary": 0, "fallback": 0}
+
+        def primary(_):
+            attempts["primary"] += 1
+            raise ValueError("config bug")
+
+        def fallback(_):
+            attempts["fallback"] += 1
+            return "FALLBACK"
+
+        mock_get.side_effect = [RunnableLambda(primary), RunnableLambda(fallback)]
+
+        result = build_resilient_llm(
+            self._config(),
+            self._config(provider="google", model="gemini-2.5-flash-lite", api_key="k2"),
+            max_attempts_per_provider=3,
+        )
+
+        with pytest.raises(ValueError, match="config bug"):
+            result.invoke("hi")
+        assert attempts["primary"] == 1
+        assert attempts["fallback"] == 0
+
+    @patch("src.llm.resilience.get_chat_model")
+    def test_transient_failure_then_recovery_logs_served_provider(self, mock_get, caplog):
+        state = {"n": 0}
+
+        def primary(_):
+            state["n"] += 1
+            if state["n"] == 1:
+                raise httpx.ConnectError("down")
+            return "RECOVERED"
+
+        mock_get.return_value = RunnableLambda(primary)
+
+        result = build_resilient_llm(self._config(), max_attempts_per_provider=3)
+
+        with caplog.at_level("INFO"):
+            assert result.invoke("hi") == "RECOVERED"
+        assert "served by provider=anthropic" in caplog.text

--- a/tests/unit/llm/test_resilience.py
+++ b/tests/unit/llm/test_resilience.py
@@ -259,7 +259,7 @@ class TestBuildResilientLLM:
         assert isinstance(exc_info.value.__cause__, httpx.ConnectError)
 
     @patch("src.llm.resilience.get_chat_model")
-    def test_transient_failure_then_recovery_logs_served_provider(self, mock_get, caplog):
+    def test_primary_success_logs_served_provider_at_debug_not_info(self, mock_get, caplog):
         state = {"n": 0}
 
         def primary(_):
@@ -272,6 +272,32 @@ class TestBuildResilientLLM:
 
         result = build_resilient_llm(self._config(), max_attempts_per_provider=3)
 
-        with caplog.at_level("INFO"):
+        with caplog.at_level("DEBUG"):
             assert result.invoke("hi") == "RECOVERED"
-        assert "served by provider=anthropic" in caplog.text
+
+        served_records = [r for r in caplog.records if "served by provider=anthropic" in r.message]
+        assert len(served_records) == 1
+        assert served_records[0].levelname == "DEBUG"
+
+    @patch("src.llm.resilience.get_chat_model")
+    def test_fallback_success_logs_served_provider_at_info(self, mock_get, caplog):
+        def primary(_):
+            raise httpx.ConnectError("down")
+
+        def fallback(_):
+            return "FALLBACK"
+
+        mock_get.side_effect = [RunnableLambda(primary), RunnableLambda(fallback)]
+
+        result = build_resilient_llm(
+            self._config(),
+            self._config(provider="google", model="gemini-2.5-flash-lite", api_key="k2"),
+            max_attempts_per_provider=1,
+        )
+
+        with caplog.at_level("DEBUG"):
+            assert result.invoke("hi") == "FALLBACK"
+
+        served_records = [r for r in caplog.records if "served by provider=google" in r.message]
+        assert len(served_records) == 1
+        assert served_records[0].levelname == "INFO"

--- a/tests/unit/llm/test_resilience.py
+++ b/tests/unit/llm/test_resilience.py
@@ -20,6 +20,7 @@ from pydantic import BaseModel, ValidationError
 from src.config.models import LLMConfig
 from src.exceptions.llm import LLMProviderError
 from src.llm.resilience import (
+    TransientLLMError,
     build_resilient_llm,
     is_transient_error,
 )
@@ -210,6 +211,23 @@ class TestBuildResilientLLM:
             result.invoke("hi")
         assert attempts["primary"] == 1
         assert attempts["fallback"] == 0
+
+    @patch("src.llm.resilience.get_chat_model")
+    def test_exhausted_retries_and_fallback_raise_transient_llm_error(self, mock_get):
+        def always_fails(_):
+            raise httpx.ConnectError("down")
+
+        mock_get.side_effect = [RunnableLambda(always_fails), RunnableLambda(always_fails)]
+
+        result = build_resilient_llm(
+            self._config(),
+            self._config(provider="google", model="gemini-2.5-flash-lite", api_key="k2"),
+            max_attempts_per_provider=2,
+        )
+
+        with pytest.raises(TransientLLMError) as exc_info:
+            result.invoke("hi")
+        assert isinstance(exc_info.value.__cause__, httpx.ConnectError)
 
     @patch("src.llm.resilience.get_chat_model")
     def test_transient_failure_then_recovery_logs_served_provider(self, mock_get, caplog):

--- a/tests/unit/llm/test_resilience.py
+++ b/tests/unit/llm/test_resilience.py
@@ -119,6 +119,11 @@ class TestBuildResilientLLM:
     def _config(self, provider="anthropic", model="claude-haiku-4-5", api_key="k"):
         return LLMConfig(provider=provider, model=model, api_key=api_key)
 
+    @pytest.mark.parametrize("bad_value", [0, -1])
+    def test_rejects_non_positive_max_attempts_per_provider(self, bad_value):
+        with pytest.raises(ValueError, match="max_attempts_per_provider"):
+            build_resilient_llm(self._config(), max_attempts_per_provider=bad_value)
+
     @patch("src.llm.resilience.get_chat_model")
     def test_no_fallback_returns_primary_only(self, mock_get):
         mock_get.return_value = RunnableLambda(lambda x: "ok")

--- a/tests/unit/llm/test_resilience.py
+++ b/tests/unit/llm/test_resilience.py
@@ -7,11 +7,13 @@ fallback whose API key is missing, and structured-output binding with
 ``include_raw=False``.
 """
 
-from typing import Optional
+from typing import Any, Dict, List, Optional
 from unittest.mock import MagicMock, patch
+from uuid import UUID
 
 import httpx
 import pytest
+from langchain_core.callbacks.base import BaseCallbackHandler
 from langchain_core.exceptions import OutputParserException
 from langchain_core.runnables import RunnableLambda
 from langchain_core.runnables.fallbacks import RunnableWithFallbacks
@@ -48,6 +50,33 @@ def _anthropic_error(status_code: int, cls: Optional[type] = None) -> BaseExcept
     response = httpx.Response(status_code, request=request, json=body)
     error_cls = cls or anthropic.APIStatusError
     return error_cls("boom", response=response, body=body)
+
+
+class _RecordingHandler(BaseCallbackHandler):
+    """Records the `name` of every chain that reports on_chain_start.
+
+    Used to lock in that callbacks registered via config={"callbacks": [...]}
+    reach the resilient_* leaf runnables, not just the outermost chain. Note:
+    this currently happens via LangChain's config contextvar and would still
+    pass even if _guard_leaf's explicit config forwarding were broken (e.g.
+    misnamed) - see _guard_leaf's docstring for that distinction.
+    """
+
+    def __init__(self) -> None:
+        self.chain_start_names: List[Optional[str]] = []
+
+    def on_chain_start(
+        self,
+        serialized: Dict[str, Any],
+        inputs: Dict[str, Any],
+        *,
+        run_id: UUID,
+        parent_run_id: Optional[UUID] = None,
+        tags: Optional[List[str]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
+    ) -> None:
+        self.chain_start_names.append(kwargs.get("name"))
 
 
 def _google_error(code: int) -> BaseException:
@@ -217,6 +246,41 @@ class TestBuildResilientLLM:
         assert result.invoke("hi") == _Schema(value=1)
         primary_model.with_structured_output.assert_called_once_with(_Schema, include_raw=False)
         fallback_model.with_structured_output.assert_called_once_with(_Schema, include_raw=False)
+
+    @patch("src.llm.resilience.get_chat_model")
+    def test_callbacks_propagate_to_primary_leaf(self, mock_get):
+        mock_get.return_value = RunnableLambda(lambda x: "ok")
+        chain = build_resilient_llm(self._config())
+        handler = _RecordingHandler()
+
+        result = chain.invoke("hi", config={"callbacks": [handler]})
+
+        assert result == "ok"
+        assert any(
+            name is not None and name.startswith("resilient_primary_")
+            for name in handler.chain_start_names
+        )
+
+    @patch("src.llm.resilience.get_chat_model")
+    def test_callbacks_propagate_to_fallback_leaf(self, mock_get):
+        def primary(_):
+            raise httpx.ConnectError("down")
+
+        mock_get.side_effect = [RunnableLambda(primary), RunnableLambda(lambda x: "FALLBACK")]
+        chain = build_resilient_llm(
+            self._config(),
+            self._config(provider="google", model="gemini-2.5-flash-lite", api_key="k2"),
+            max_attempts_per_provider=1,
+        )
+        handler = _RecordingHandler()
+
+        result = chain.invoke("hi", config={"callbacks": [handler]})
+
+        assert result == "FALLBACK"
+        assert any(
+            name is not None and name.startswith("resilient_fallback_")
+            for name in handler.chain_start_names
+        )
 
     @patch("src.llm.resilience.get_chat_model")
     def test_transient_primary_failure_falls_back(self, mock_get):

--- a/tests/unit/llm/test_resilience.py
+++ b/tests/unit/llm/test_resilience.py
@@ -7,6 +7,7 @@ fallback whose API key is missing, and structured-output binding with
 ``include_raw=False``.
 """
 
+from typing import Optional
 from unittest.mock import MagicMock, patch
 
 import httpx
@@ -36,12 +37,15 @@ def _make_validation_error() -> ValidationError:
     raise AssertionError("expected ValidationError")
 
 
-def _anthropic_rate_limit() -> BaseException:
+def _anthropic_error(status_code: int, cls: Optional[type] = None) -> BaseException:
+    """Build a real Anthropic APIStatusError (subclass) with a given status code."""
     import anthropic
 
-    # Construct without running __init__ (its signature needs an httpx response);
-    # isinstance-based classification only cares about the type.
-    return anthropic.RateLimitError.__new__(anthropic.RateLimitError)
+    request = httpx.Request("POST", "https://api.anthropic.com/v1/messages")
+    body = {"error": {"type": "x", "message": "boom"}}
+    response = httpx.Response(status_code, request=request, json=body)
+    error_cls = cls or anthropic.APIStatusError
+    return error_cls("boom", response=response, body=body)
 
 
 def _google_error(code: int) -> BaseException:
@@ -63,7 +67,6 @@ class TestIsTransientError:
             httpx.ConnectError("no route"),
             OutputParserException("bad json"),
             _make_validation_error(),
-            _anthropic_rate_limit(),
         ],
     )
     def test_transient_exceptions(self, exc):
@@ -80,6 +83,21 @@ class TestIsTransientError:
 
     def test_google_auth_error_is_fail_fast(self):
         assert is_transient_error(_google_error(401)) is False
+
+    @pytest.mark.parametrize("status_code", [429, 500, 503, 504, 529])
+    def test_anthropic_status_codes_are_transient(self, status_code):
+        assert is_transient_error(_anthropic_error(status_code)) is True
+
+    def test_anthropic_connection_error_is_transient(self):
+        import anthropic
+
+        request = httpx.Request("POST", "https://api.anthropic.com/v1/messages")
+        exc = anthropic.APIConnectionError(request=request)
+        assert is_transient_error(exc) is True
+
+    @pytest.mark.parametrize("status_code", [400, 401, 403, 404, 422])
+    def test_anthropic_status_codes_are_fail_fast(self, status_code):
+        assert is_transient_error(_anthropic_error(status_code)) is False
 
     @pytest.mark.parametrize(
         "exc",


### PR DESCRIPTION
Add a reusable LLM call-resilience building block (`src/llm/resilience.py`) — the first instance of the pattern from the interview-prep multi-agent rework (T1). It is a self-contained addition that does not touch the running workflow graph.

- Add `build_resilient_llm()` composing a same-provider transient retry (`with_retry`) under a cross-provider fallback (`with_fallbacks`), binding `with_structured_output(include_raw=False)` per model before fallback composition (honors both documented correctness traps)
- Add provider-agnostic `is_transient_error()` classifier (transient → retry+fallback; auth/malformed/unknown → fail fast), made status-code-aware for the new `google.genai` SDK which collapses all 4xx into one `ClientError`
- Normalize transient failures into `TransientLLMError` so the native retry/fallback type filters stay consistent with the classifier
- Skip the fallback gracefully when its API key is missing (single-key envs don't crash); log which provider+model served each response and propagate the tracing config across the fallback boundary
- Export helpers from `src/llm` and add 20 unit tests

Retry knobs are plain arguments with defaults so this block has no dependency on the later config work (T2 wires `[llm.resilience]` / `RetryConfig` in).

Testing: full suite green (320 passed); `ruff check`/`format` clean; `mypy` reports no new errors in the added module.

Refs: JSA-44