### PR TITLE
feat(config): add per-task LLM configs and resilience settings for interview-prep

### DIFF
--- a/configs/base.toml
+++ b/configs/base.toml
@@ -51,6 +51,61 @@ model = "gemini-2.5-flash-lite"
 temperature = 0.7
 max_tokens = 4096
 
+[agent_tasks.interview_research_planning]
+provider = "google"
+model = "gemini-2.5-flash-lite"
+temperature = 0.3
+max_tokens = 4096
+
+[agent_tasks.interview_research_critic]
+provider = "google"
+model = "gemini-2.5-flash-lite"
+temperature = 0.0
+max_tokens = 4096
+
+[agent_tasks.interview_question_critic]
+provider = "google"
+model = "gemini-2.5-flash-lite"
+temperature = 0.0
+max_tokens = 4096
+
+[agent_tasks.interview_guide_synthesis]
+provider = "google"
+model = "gemini-2.5-flash-lite"
+temperature = 0.5
+max_tokens = 4096
+
+# Interview-prep workflow orchestration: bounds on the bounded critic gates
+# (research and questions), and per-gate enable toggles (e.g. for a future
+# free tier that skips quality gates).
+[interview_prep]
+max_research_attempts = 2
+max_question_attempts = 2
+enable_research_critic = true
+enable_question_critic = true
+
+# Global LLM call-resilience defaults (see src/llm/resilience.py): same-provider
+# retry/backoff shape, plus a cross-provider fallback map grouped by
+# cost/capability tier so a fallback never silently downgrades a task onto a
+# much weaker model (e.g. a "standard"-tier google task never falls back to a
+# "cheap"-tier anthropic model). Any agent_tasks.<task> may set its own
+# `fallback = { provider = "...", model = "..." }` to bypass this tier lookup.
+[llm.resilience.retry]
+max_attempts_per_provider = 3
+wait_exponential_jitter = true
+
+[llm.resilience.fallback_tiers.cheap]
+google = "gemini-2.5-flash-lite"
+anthropic = "claude-haiku-4-5"
+
+[llm.resilience.fallback_tiers.standard]
+google = "gemini-2.5-flash"
+anthropic = "claude-sonnet-4-6"
+
+[llm.resilience.fallback_tiers.premium]
+google = "gemini-2.5-pro"
+anthropic = "claude-opus-4-7"
+
 [observability.langfuse]
 enabled = false
 host = "https://us.cloud.langfuse.com"

--- a/src/config/models.py
+++ b/src/config/models.py
@@ -41,6 +41,88 @@ class LoggingConfig(BaseModel):
         return v.upper()
 
 
+# Shared by LLMConfig and FallbackTarget so both validate providers/models
+# identically without one class depending on the other's definition order.
+_VALID_PROVIDERS: frozenset = frozenset({"anthropic", "google"})
+
+_VALID_MODELS_BY_PROVIDER: Dict[str, set] = {
+    "anthropic": {
+        "claude-haiku-4-5",
+        "claude-haiku-4-5-20251001",
+        "claude-sonnet-4-6",
+        "claude-sonnet-4-20250514",
+        "claude-opus-4-7",
+    },
+    "google": {
+        "gemini-3.5-flash",
+        "gemini-2.5-pro",
+        "gemini-2.5-flash",
+        "gemini-2.5-flash-lite",
+    },
+}
+
+
+def _validate_provider_name(v: str) -> str:
+    """Validate that a provider name is supported, normalizing to lowercase."""
+    if v.lower() not in _VALID_PROVIDERS:
+        raise ValueError(f"Provider must be one of: {', '.join(sorted(_VALID_PROVIDERS))}")
+    return v.lower()
+
+
+def _validate_model_name(v: str, provider: str) -> str:
+    """Validate that a model is supported for the given provider.
+
+    Skipped for stage environments or test/stage-style model names, so
+    fixtures and integration stubs don't need to name a real model.
+    """
+    current_env = os.getenv("APP_ENV", "").lower()
+    if (
+        current_env == Environment.STAGE.value
+        or v.startswith("stage")
+        or v.startswith("test")
+        or "stage" in v.lower()
+        or "test" in v.lower()
+    ):
+        return v
+
+    provider = provider.lower()
+    if provider in _VALID_MODELS_BY_PROVIDER:
+        valid_models = _VALID_MODELS_BY_PROVIDER[provider]
+        if v not in valid_models:
+            raise ValueError(
+                f"Model '{v}' not supported for provider '{provider}'. "
+                f"Valid models: {', '.join(sorted(valid_models))}"
+            )
+
+    return v
+
+
+class FallbackTarget(BaseModel):
+    """A provider+model pair identifying an LLM call-resilience fallback target.
+
+    Used both for the global tier-matched fallback map
+    (``LLMResilienceConfig.fallback_tiers``) and for a per-task override
+    (``LLMConfig.fallback``). Sampling settings aren't part of this: when a
+    fallback is actually built, it borrows ``temperature``/``max_tokens``
+    from the primary task's own config - only the provider/model differ.
+    """
+
+    provider: str = Field(..., description="Fallback provider")
+    model: str = Field(..., description="Fallback model identifier")
+
+    @field_validator("provider")
+    @classmethod
+    def validate_provider(cls, v: str) -> str:
+        """Validate that provider is supported."""
+        return _validate_provider_name(v)
+
+    @field_validator("model")
+    @classmethod
+    def validate_model(cls, v: str, info) -> str:
+        """Validate that model is supported for the provider."""
+        return _validate_model_name(v, info.data.get("provider", ""))
+
+
 class LLMConfig(BaseModel):
     """Configuration for a single LLM (provider, model, and sampling settings)."""
 
@@ -51,59 +133,28 @@ class LLMConfig(BaseModel):
     api_key: Optional[str] = Field(
         default=None, description="API key for the provider (from env var)"
     )
+    fallback: Optional[FallbackTarget] = Field(
+        default=None,
+        description=(
+            "Optional override of the global tier-matched resilience fallback "
+            "(AppConfig.llm.resilience.fallback_tiers) for this task only."
+        ),
+    )
 
     # Valid models for each provider
-    VALID_MODELS: ClassVar[Dict[str, set]] = {
-        "anthropic": {
-            "claude-haiku-4-5",
-            "claude-haiku-4-5-20251001",
-            "claude-sonnet-4-6",
-            "claude-sonnet-4-20250514",
-            "claude-opus-4-7",
-        },
-        "google": {
-            "gemini-3.5-flash",
-            "gemini-2.5-pro",
-            "gemini-2.5-flash",
-            "gemini-2.5-flash-lite",
-        },
-    }
+    VALID_MODELS: ClassVar[Dict[str, set]] = _VALID_MODELS_BY_PROVIDER
 
     @field_validator("provider")
     @classmethod
     def validate_provider(cls, v: str) -> str:
         """Validate that provider is supported."""
-        valid_providers = {"anthropic", "google"}
-        if v.lower() not in valid_providers:
-            raise ValueError(f"Provider must be one of: {', '.join(valid_providers)}")
-        return v.lower()
+        return _validate_provider_name(v)
 
     @field_validator("model")
     @classmethod
     def validate_model(cls, v: str, info) -> str:
         """Validate that model is supported for the provider."""
-        # Skip validation in stage environments or for test/stage models
-        current_env = os.getenv("APP_ENV", "").lower()
-        if (
-            current_env == Environment.STAGE.value
-            or v.startswith("stage")
-            or v.startswith("test")
-            or "stage" in v.lower()
-            or "test" in v.lower()
-        ):
-            return v
-
-        provider = info.data.get("provider", "").lower()
-
-        if provider in cls.VALID_MODELS:
-            valid_models = cls.VALID_MODELS[provider]
-            if v not in valid_models:
-                raise ValueError(
-                    f"Model '{v}' not supported for provider '{provider}'. "
-                    f"Valid models: {', '.join(sorted(valid_models))}"
-                )
-
-        return v
+        return _validate_model_name(v, info.data.get("provider", ""))
 
     @field_validator("api_key")
     @classmethod
@@ -169,6 +220,149 @@ class AgentTasksConfig(BaseModel):
         ..., description="LLM config for answer generation"
     )
     interview_compilation: LLMConfig = Field(..., description="LLM config for guide compilation")
+    interview_research_planning: LLMConfig = Field(
+        ..., description="LLM config for the research-planner node (JD/resume -> query plan)"
+    )
+    interview_research_critic: LLMConfig = Field(
+        ..., description="LLM config for the post-research quality gate"
+    )
+    interview_question_critic: LLMConfig = Field(
+        ..., description="LLM config for the post-question quality gate"
+    )
+    interview_guide_synthesis: LLMConfig = Field(
+        ..., description="LLM config for research-summary and prep-tips synthesis"
+    )
+
+
+class RetryConfig(BaseModel):
+    """Same-provider retry/backoff shape for the LLM call-resilience layer.
+
+    Maps onto ``Runnable.with_retry``'s parameters (see
+    ``src/llm/resilience.py``): ``jitter_*`` fields are optional overrides
+    for Tenacity's ``wait_exponential_jitter``; unset ones fall back to
+    Tenacity's own defaults via :meth:`exponential_jitter_params`.
+    """
+
+    max_attempts_per_provider: int = Field(
+        default=3,
+        ge=1,
+        description="Same-provider attempts before falling back to another provider (or failing)",
+    )
+    wait_exponential_jitter: bool = Field(
+        default=True,
+        description="Use exponential backoff with jitter between same-provider attempts",
+    )
+    jitter_initial: Optional[float] = Field(
+        default=None,
+        gt=0,
+        description="Tenacity wait_exponential_jitter 'initial' override (seconds)",
+    )
+    jitter_max: Optional[float] = Field(
+        default=None, gt=0, description="Tenacity wait_exponential_jitter 'max' override (seconds)"
+    )
+    jitter_exp_base: Optional[float] = Field(
+        default=None, gt=0, description="Tenacity wait_exponential_jitter 'exp_base' override"
+    )
+
+    def exponential_jitter_params(self) -> Optional[Dict[str, float]]:
+        """Build kwargs for ``with_retry``'s ``exponential_jitter_params``.
+
+        Returns ``None`` (letting Tenacity use its own defaults) when none of
+        the jitter fields have been overridden.
+        """
+        params = {
+            "initial": self.jitter_initial,
+            "max": self.jitter_max,
+            "exp_base": self.jitter_exp_base,
+        }
+        set_params = {k: v for k, v in params.items() if v is not None}
+        return set_params or None
+
+
+class LLMResilienceConfig(BaseModel):
+    """Global defaults for the LLM call-resilience layer (see ``src/llm/resilience.py``).
+
+    ``fallback_tiers`` groups equivalent cost/capability models across
+    providers (e.g. a "cheap" tier pairing google's flash-lite with
+    anthropic's haiku) so a fallback never silently downgrades a task onto a
+    much weaker model. Any ``agent_tasks.<task>.fallback`` overrides this
+    tier lookup for that one task.
+    """
+
+    retry: RetryConfig = Field(
+        default_factory=RetryConfig, description="Default retry/backoff shape for every task"
+    )
+    fallback_tiers: Dict[str, Dict[str, str]] = Field(
+        default_factory=dict,
+        description="Tier name -> {provider: model}, for cross-provider same-tier fallback",
+    )
+
+    @field_validator("fallback_tiers")
+    @classmethod
+    def validate_fallback_tiers(cls, v: Dict[str, Dict[str, str]]) -> Dict[str, Dict[str, str]]:
+        """Validate and normalize every (provider, model) pair in every tier."""
+        normalized: Dict[str, Dict[str, str]] = {}
+        for tier_name, providers in v.items():
+            normalized_providers: Dict[str, str] = {}
+            for provider, model in providers.items():
+                provider_norm = _validate_provider_name(provider)
+                normalized_providers[provider_norm] = _validate_model_name(model, provider_norm)
+            normalized[tier_name] = normalized_providers
+        return normalized
+
+    def resolve_fallback(self, primary: LLMConfig) -> Optional[FallbackTarget]:
+        """Resolve the fallback target for a primary task config.
+
+        A per-task ``primary.fallback`` override always wins. Otherwise, find
+        the tier that contains ``primary``'s (provider, model) pair and
+        return the *other* provider's model from that same tier. Returns
+        ``None`` if there is no override and no tier contains this
+        provider/model pairing, so callers can fall back to primary-only
+        retries instead of guessing a mismatched-tier fallback.
+        """
+        if primary.fallback is not None:
+            return primary.fallback
+
+        for providers in self.fallback_tiers.values():
+            if providers.get(primary.provider) != primary.model:
+                continue
+            for other_provider, other_model in providers.items():
+                if other_provider != primary.provider:
+                    return FallbackTarget(provider=other_provider, model=other_model)
+
+        return None
+
+
+class LLMSettingsConfig(BaseModel):
+    """Top-level ``[llm]`` configuration section."""
+
+    resilience: LLMResilienceConfig = Field(
+        default_factory=LLMResilienceConfig, description="Global LLM call-resilience configuration"
+    )
+
+
+class InterviewPrepConfig(BaseModel):
+    """Orchestration knobs for the interview-prep multi-agent workflow.
+
+    Bound the two bounded critic gates (research and questions) so retries
+    are structurally capped, and let each gate be disabled independently
+    (e.g. for a future free tier that skips quality gates).
+    """
+
+    max_research_attempts: int = Field(
+        default=2, ge=1, description="Max research re-plans before proceeding with best effort"
+    )
+    max_question_attempts: int = Field(
+        default=2,
+        ge=1,
+        description="Max question-regeneration rounds before proceeding with best effort",
+    )
+    enable_research_critic: bool = Field(
+        default=True, description="Toggle the post-research quality gate"
+    )
+    enable_question_critic: bool = Field(
+        default=True, description="Toggle the post-question quality gate"
+    )
 
 
 class LangfuseConfig(BaseModel):
@@ -202,4 +396,11 @@ class AppConfig(BaseModel):
     general: GeneralConfig = Field(..., description="General application configuration")
     logging: LoggingConfig = Field(..., description="Logging configuration")
     agent_tasks: AgentTasksConfig = Field(..., description="Per-task LLM configuration")
+    llm: LLMSettingsConfig = Field(
+        default_factory=LLMSettingsConfig, description="Global LLM configuration (call resilience)"
+    )
+    interview_prep: InterviewPrepConfig = Field(
+        default_factory=InterviewPrepConfig,
+        description="Interview-prep workflow orchestration knobs",
+    )
     observability: ObservabilityConfig = Field(..., description="Observability configuration")

--- a/tests/unit/config/test_models.py
+++ b/tests/unit/config/test_models.py
@@ -1,0 +1,230 @@
+"""
+Unit tests for the Pydantic configuration models in src/config/models.py.
+
+Focuses on the pieces added for per-task interview-prep LLM configs, the
+interview-prep orchestration knobs, and the global LLM call-resilience
+config (retry shape + cross-provider tier-matched fallback mapping, with
+optional per-task override).
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from src.config.models import (
+    AppConfig,
+    FallbackTarget,
+    InterviewPrepConfig,
+    LLMConfig,
+    LLMResilienceConfig,
+    LLMSettingsConfig,
+    RetryConfig,
+)
+
+# APP_ENV=stage is set globally in tests/conftest.py, which skips both the
+# model-catalog and API-key validators. Use real-looking model names anyway
+# so these tests still document/exercise realistic values.
+
+
+class TestFallbackTarget:
+    """FallbackTarget validates provider/model like LLMConfig does."""
+
+    def test_valid_provider_and_model(self):
+        target = FallbackTarget(provider="ANTHROPIC", model="claude-haiku-4-5")
+
+        assert target.provider == "anthropic"  # normalized to lowercase
+        assert target.model == "claude-haiku-4-5"
+
+    def test_invalid_provider_rejected(self):
+        with pytest.raises(ValidationError, match="Provider must be one of"):
+            FallbackTarget(provider="openai", model="gpt-4")
+
+
+class TestLLMConfigFallbackField:
+    """LLMConfig carries an optional per-task fallback override."""
+
+    def test_fallback_defaults_to_none(self):
+        config = LLMConfig(provider="google", model="gemini-2.5-flash-lite")
+
+        assert config.fallback is None
+
+    def test_fallback_can_be_set(self):
+        config = LLMConfig(
+            provider="google",
+            model="gemini-2.5-flash-lite",
+            fallback=FallbackTarget(provider="anthropic", model="claude-haiku-4-5"),
+        )
+
+        assert config.fallback == FallbackTarget(provider="anthropic", model="claude-haiku-4-5")
+
+    def test_fallback_not_part_of_hash_or_equality(self):
+        """Fallback is a resilience-layer concern, not part of the primary
+        model's identity, so two otherwise-identical configs with different
+        fallbacks are still equal/hash equal."""
+        base = LLMConfig(provider="google", model="gemini-2.5-flash-lite")
+        with_fallback = LLMConfig(
+            provider="google",
+            model="gemini-2.5-flash-lite",
+            fallback=FallbackTarget(provider="anthropic", model="claude-haiku-4-5"),
+        )
+
+        assert base == with_fallback
+        assert hash(base) == hash(with_fallback)
+
+
+class TestRetryConfig:
+    """RetryConfig defaults and the exponential_jitter_params() helper."""
+
+    def test_defaults(self):
+        retry = RetryConfig()
+
+        assert retry.max_attempts_per_provider == 3
+        assert retry.wait_exponential_jitter is True
+        assert retry.exponential_jitter_params() is None
+
+    def test_rejects_non_positive_max_attempts(self):
+        with pytest.raises(ValidationError):
+            RetryConfig(max_attempts_per_provider=0)
+
+    def test_exponential_jitter_params_only_includes_set_fields(self):
+        retry = RetryConfig(jitter_initial=1.0, jitter_max=30.0)
+
+        assert retry.exponential_jitter_params() == {"initial": 1.0, "max": 30.0}
+
+    def test_exponential_jitter_params_all_fields(self):
+        retry = RetryConfig(jitter_initial=1.0, jitter_max=30.0, jitter_exp_base=2.0)
+
+        assert retry.exponential_jitter_params() == {
+            "initial": 1.0,
+            "max": 30.0,
+            "exp_base": 2.0,
+        }
+
+
+class TestLLMResilienceConfig:
+    """Fallback-tier validation and tier-matched resolution."""
+
+    def _resilience_config(self) -> LLMResilienceConfig:
+        return LLMResilienceConfig(
+            fallback_tiers={
+                "cheap": {"google": "gemini-2.5-flash-lite", "anthropic": "claude-haiku-4-5"},
+                "standard": {"google": "gemini-2.5-flash", "anthropic": "claude-sonnet-4-6"},
+            }
+        )
+
+    def test_defaults_to_empty_tiers_and_default_retry(self):
+        resilience = LLMResilienceConfig()
+
+        assert resilience.fallback_tiers == {}
+        assert resilience.retry == RetryConfig()
+
+    def test_fallback_tiers_normalizes_provider_case(self):
+        resilience = LLMResilienceConfig(
+            fallback_tiers={"cheap": {"GOOGLE": "gemini-2.5-flash-lite"}}
+        )
+
+        assert resilience.fallback_tiers == {"cheap": {"google": "gemini-2.5-flash-lite"}}
+
+    def test_fallback_tiers_rejects_invalid_provider(self):
+        with pytest.raises(ValidationError, match="Provider must be one of"):
+            LLMResilienceConfig(fallback_tiers={"cheap": {"openai": "gpt-4"}})
+
+    def test_resolve_fallback_matches_tier(self):
+        resilience = self._resilience_config()
+        primary = LLMConfig(provider="google", model="gemini-2.5-flash-lite")
+
+        fallback = resilience.resolve_fallback(primary)
+
+        assert fallback == FallbackTarget(provider="anthropic", model="claude-haiku-4-5")
+
+    def test_resolve_fallback_is_tier_matched_not_cross_tier(self):
+        """A 'standard'-tier google task must not fall back to the 'cheap'
+        anthropic model, even though both tiers reference anthropic."""
+        resilience = self._resilience_config()
+        primary = LLMConfig(provider="google", model="gemini-2.5-flash")
+
+        fallback = resilience.resolve_fallback(primary)
+
+        assert fallback == FallbackTarget(provider="anthropic", model="claude-sonnet-4-6")
+
+    def test_resolve_fallback_returns_none_when_no_tier_matches(self):
+        resilience = self._resilience_config()
+        primary = LLMConfig(provider="google", model="gemini-2.5-pro")  # premium, no tier defined
+
+        assert resilience.resolve_fallback(primary) is None
+
+    def test_resolve_fallback_returns_none_with_no_tiers_configured(self):
+        resilience = LLMResilienceConfig()
+        primary = LLMConfig(provider="google", model="gemini-2.5-flash-lite")
+
+        assert resilience.resolve_fallback(primary) is None
+
+    def test_per_task_override_wins_over_tier_lookup(self):
+        resilience = self._resilience_config()
+        primary = LLMConfig(
+            provider="google",
+            model="gemini-2.5-flash-lite",
+            fallback=FallbackTarget(provider="anthropic", model="claude-opus-4-7"),
+        )
+
+        fallback = resilience.resolve_fallback(primary)
+
+        assert fallback == FallbackTarget(provider="anthropic", model="claude-opus-4-7")
+
+
+class TestInterviewPrepConfig:
+    """Orchestration knob defaults."""
+
+    def test_defaults(self):
+        cfg = InterviewPrepConfig()
+
+        assert cfg.max_research_attempts == 2
+        assert cfg.max_question_attempts == 2
+        assert cfg.enable_research_critic is True
+        assert cfg.enable_question_critic is True
+
+    def test_gates_can_be_disabled(self):
+        cfg = InterviewPrepConfig(enable_research_critic=False, enable_question_critic=False)
+
+        assert cfg.enable_research_critic is False
+        assert cfg.enable_question_critic is False
+
+    @pytest.mark.parametrize("field", ["max_research_attempts", "max_question_attempts"])
+    def test_rejects_non_positive_attempts(self, field):
+        with pytest.raises(ValidationError):
+            InterviewPrepConfig(**{field: 0})
+
+
+class TestAppConfigDefaults:
+    """AppConfig fills in llm/interview_prep with defaults when omitted,
+    so configs predating this feature still validate."""
+
+    def _minimal_kwargs(self):
+        from src.config.models import AgentTasksConfig, ObservabilityConfig
+
+        task = LLMConfig(provider="google", model="gemini-2.5-flash-lite")
+        agent_tasks = AgentTasksConfig(
+            job_evaluation_extraction=task,
+            job_evaluation_fit=task,
+            interview_research=task,
+            interview_question_generation=task,
+            interview_answer_generation=task,
+            interview_compilation=task,
+            interview_research_planning=task,
+            interview_research_critic=task,
+            interview_question_critic=task,
+            interview_guide_synthesis=task,
+        )
+        return {
+            "general": {"name": "test", "tagline": "test", "version": "0.0.0"},
+            "logging": {},
+            "agent_tasks": agent_tasks,
+            "observability": ObservabilityConfig(),
+        }
+
+    def test_llm_and_interview_prep_default_when_omitted(self):
+        app_config = AppConfig(**self._minimal_kwargs())
+
+        assert isinstance(app_config.llm, LLMSettingsConfig)
+        assert app_config.llm.resilience.fallback_tiers == {}
+        assert isinstance(app_config.interview_prep, InterviewPrepConfig)
+        assert app_config.interview_prep.max_research_attempts == 2

--- a/tests/unit/config/test_system.py
+++ b/tests/unit/config/test_system.py
@@ -49,6 +49,22 @@ model = "stage-test-model"
 [agent_tasks.interview_compilation]
 provider = "anthropic"
 model = "stage-test-model"
+
+[agent_tasks.interview_research_planning]
+provider = "anthropic"
+model = "stage-test-model"
+
+[agent_tasks.interview_research_critic]
+provider = "anthropic"
+model = "stage-test-model"
+
+[agent_tasks.interview_question_critic]
+provider = "anthropic"
+model = "stage-test-model"
+
+[agent_tasks.interview_guide_synthesis]
+provider = "anthropic"
+model = "stage-test-model"
 """
 
 
@@ -509,6 +525,30 @@ temperature = 0.1
 max_tokens = 2048
 
 [agent_tasks.interview_compilation]
+provider = "anthropic"
+model = "claude-haiku-4-5"
+temperature = 0.1
+max_tokens = 2048
+
+[agent_tasks.interview_research_planning]
+provider = "anthropic"
+model = "claude-haiku-4-5"
+temperature = 0.1
+max_tokens = 2048
+
+[agent_tasks.interview_research_critic]
+provider = "anthropic"
+model = "claude-haiku-4-5"
+temperature = 0.1
+max_tokens = 2048
+
+[agent_tasks.interview_question_critic]
+provider = "anthropic"
+model = "claude-haiku-4-5"
+temperature = 0.1
+max_tokens = 2048
+
+[agent_tasks.interview_guide_synthesis]
 provider = "anthropic"
 model = "claude-haiku-4-5"
 temperature = 0.1

--- a/tests/unit/integration/test_environment_check.py
+++ b/tests/unit/integration/test_environment_check.py
@@ -34,6 +34,10 @@ def _make_agent_tasks(**overrides: LLMConfig) -> AgentTasksConfig:
         "interview_question_generation": default,
         "interview_answer_generation": default,
         "interview_compilation": default,
+        "interview_research_planning": default,
+        "interview_research_critic": default,
+        "interview_question_critic": default,
+        "interview_guide_synthesis": default,
     }
     fields.update(overrides)
     return AgentTasksConfig(**fields)


### PR DESCRIPTION
Add the config surface for the interview-prep multi-agent rework's new nodes and its LLM call-resilience layer, so later work can wire nodes against real config instead of hardcoded values.

- Add four new interview-prep agent-task LLM configs (research planning, research critic, question critic, guide synthesis) to `AgentTasksConfig` and `configs/base.toml`
- Add `interview_prep` orchestration knobs: max research/question attempts, and independent enable toggles for the research/question critic gates
- Add a global `[llm.resilience]` section: `RetryConfig` (max attempts per provider, backoff params) plus a cross-provider, tier-matched fallback mapping (e.g. cheap google <-> cheap anthropic), with an optional per-task override via `LLMConfig.fallback`
- Add `LLMResilienceConfig.resolve_fallback()` to resolve a task's fallback target (override first, else tier lookup)
- Add unit tests for the new config models, fallback-tier validation, and resolution; update existing config fixtures for the four new required agent tasks

Refs: JSA-44